### PR TITLE
feat(success-and-error-banners): Add project to demonstrate action feedback messages

### DIFF
--- a/success-and-error-banners/.gitignore
+++ b/success-and-error-banners/.gitignore
@@ -1,0 +1,20 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# dotenv environment variables file
+.env
+.env.test
+
+# Serverless directories
+.serverless/
+
+# HubSpot config file
+hubspot.config.yml

--- a/success-and-error-banners/README.md
+++ b/success-and-error-banners/README.md
@@ -1,0 +1,14 @@
+# success-and-error-banners
+
+This example project demonstrates how to display success and error banners as feedback to a user action, like clicking a button. These can be helpful when communicating whether a given request, especially to a third-party API, has succeeded or failed.
+
+For the purposes of this example, the GET request randomly succeeds or fails each time the button is clicked.
+
+![success-and-error-example](https://user-images.githubusercontent.com/5553591/183501320-a7048093-799d-4d49-a23b-83942746a5d6.gif)
+
+## How to use
+
+This project can be used as-is in a HubSpot account by:
+1. Cloning this repository
+2. `cd success-and-error-banners`
+3. `hs project upload`

--- a/success-and-error-banners/hsproject.json
+++ b/success-and-error-banners/hsproject.json
@@ -1,0 +1,4 @@
+{
+  "name": "success-and-error-banners",
+  "srcDir": "src"
+}

--- a/success-and-error-banners/src/app/app.functions/action-feedback-banner.js
+++ b/success-and-error-banners/src/app/app.functions/action-feedback-banner.js
@@ -1,0 +1,29 @@
+// For external API calls
+const axios = require('axios');
+
+exports.main = async (context = {}, sendResponse) => {
+  // Randomly choose between a valid and invalid URL to display for success and error demonstration purposes
+  const isValidEndpoint = Math.round(Math.random());
+  const endpoint = isValidEndpoint ? 'https://www.hubspot.com' : 'https://www.hubspot.com/doesnotexist';
+
+  try {
+    // Arbitrary request against an endpoint
+    await axios.get(endpoint);
+
+    // Creates a transient, successful feedback banner when request is successful
+    sendResponse({
+      message: {
+        type: 'SUCCESS',
+        body: 'Action was successful'
+      }
+    });
+  } catch (error) {
+    // Creates an error feedback banner when it catches an error
+    sendResponse({
+      message: {
+        type: 'ERROR',
+        body: `Error: ${error.message}`
+      }
+    });
+  }
+};

--- a/success-and-error-banners/src/app/app.functions/crm-card.js
+++ b/success-and-error-banners/src/app/app.functions/crm-card.js
@@ -1,0 +1,19 @@
+exports.main = async (context = {}, sendResponse) => {
+  // Displays a button that will call the action-feedback-banner function when clicked
+  sendResponse({
+    sections: [
+      {
+        type: 'text',
+        text: "This button will display a success or error banner to indicate the result of the button's action."
+      },
+      {
+        type: 'button',
+        text: 'Show feedback message',
+        onClick: {
+          type: 'SERVERLESS_ACTION_HOOK',
+          serverlessFunction: 'action-feedback-banner'
+        },
+      },
+    ],
+  });
+};

--- a/success-and-error-banners/src/app/app.functions/serverless.json
+++ b/success-and-error-banners/src/app/app.functions/serverless.json
@@ -1,0 +1,13 @@
+{
+  "runtime": "nodejs12.x",
+  "version": "1.0",
+  "appFunctions": {
+    "crm-card": {
+      "file": "crm-card.js",
+      "secrets": []
+    },
+    "action-feedback-banner": {
+      "file": "action-feedback-banner.js"
+    }
+  }
+}

--- a/success-and-error-banners/src/app/app.json
+++ b/success-and-error-banners/src/app/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "Success and error banners",
+  "description": "",
+  "scopes": [
+    "crm.objects.contacts.read",
+    "crm.objects.contacts.write"
+  ],
+  "public": false,
+  "extensions": {
+    "crm": {
+      "cards": [
+        {
+          "file": "./crm-card.json",
+          "version": 2
+        }
+      ]
+    }
+  }
+}

--- a/success-and-error-banners/src/app/crm-card.json
+++ b/success-and-error-banners/src/app/crm-card.json
@@ -1,0 +1,15 @@
+{
+  "type": "crm-card",
+  "version": 2,
+  "data": {
+    "title": "Success and error banners",
+    "fetch": {
+      "targetFunction": "crm-card",
+      "objectTypes": [
+        {
+          "name": "contacts"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This example project demonstrates how to display success and error banners as feedback to a user action, like clicking a button. These can be helpful when communicating whether a given request, especially to a third-party API, has succeeded or failed.

For the purposes of this example, the GET request randomly succeeds or fails each time the button is clicked.

![success-and-error-banners](https://user-images.githubusercontent.com/5553591/183501320-a7048093-799d-4d49-a23b-83942746a5d6.gif)
