### PR TITLE
fix: Set propertiesToSend to empty array to prevent new validation error

### DIFF
--- a/display-iframe/src/app/crm-card.json
+++ b/display-iframe/src/app/crm-card.json
@@ -7,7 +7,8 @@
       "targetFunction": "crm-card",
       "objectTypes": [
         {
-          "name": "contacts"
+          "name": "contacts",
+          "propertiesToSend": []
         }
       ]
     }

--- a/success-and-error-banners/src/app/crm-card.json
+++ b/success-and-error-banners/src/app/crm-card.json
@@ -7,7 +7,8 @@
       "targetFunction": "crm-card",
       "objectTypes": [
         {
-          "name": "contacts"
+          "name": "contacts",
+          "propertiesToSend": []
         }
       ]
     }


### PR DESCRIPTION
The build now throws an error when `propertiesToSend` is not provided, so this PR explicitly sets `propertiesToSend` to an empty array.

```
[ERROR] There was an error parsing the JSON for the file `crm-card.json`. error = `object has missing required properties (["propertiesToSend"])`
```