### PR TITLE
feat(include-npm-dependencies): Add example for using npm dependencies

### DIFF
--- a/include-npm-dependencies/.gitignore
+++ b/include-npm-dependencies/.gitignore
@@ -1,0 +1,20 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# dotenv environment variables file
+.env
+.env.test
+
+# Serverless directories
+.serverless/
+
+# HubSpot config file
+hubspot.config.yml

--- a/include-npm-dependencies/README.md
+++ b/include-npm-dependencies/README.md
@@ -1,0 +1,23 @@
+# include-npm-dependencies
+
+![include-npm-dependencies-example](https://user-images.githubusercontent.com/5553591/184923750-a72c8e3d-4b42-4848-a355-7d528a4c466b.png)
+
+## How to use
+
+This project can be used as-is in a HubSpot account by:
+1. Cloning this repository
+2. `cd include-npm-dependencies`
+3. `hs project upload`
+
+## How it works
+
+To add an npm dependency to a project, there must be a `package.json` file in the `src/app/app.functions/` folder with an npm package specified in the `dependencies` object.
+1. `cd include-npm-dependencies/src/app/app.functions/`
+2. Run `npm init`. This `npm init` command will walk through the creation of the `package.json` file.
+3. Next, an npm dependency can be included using `npm install`. Example: `npm install dayjs` installs the [`dayjs` npm package](https://www.npmjs.com/package/dayjs) as a dependency, and adds it to the `dependencies` object in the `package.json`.
+
+Now the `dayjs` library can be imported into files like `crm-card.js`. In this example project, we do this through:
+
+```js
+const dayjs = require('dayjs');
+```

--- a/include-npm-dependencies/hsproject.json
+++ b/include-npm-dependencies/hsproject.json
@@ -1,0 +1,4 @@
+{
+  "name": "include-npm-dependencies",
+  "srcDir": "src"
+}

--- a/include-npm-dependencies/src/app/app.functions/crm-card.js
+++ b/include-npm-dependencies/src/app/app.functions/crm-card.js
@@ -1,0 +1,17 @@
+const dayjs = require('dayjs');
+
+exports.main = async (context, sendResponse) => {
+  sendResponse({
+    sections: [
+      {
+        type: 'text',
+        format: 'markdown',
+        text: 'This project demonstrates how to include and use an npm dependency, using [day.js](https://www.npmjs.com/package/dayjs) as an example.'
+      },
+      {
+        type: 'text',
+        text: `Date formatting with day.js: ${dayjs().format('M/D/YYYY')}`
+      }
+    ],
+  });
+};

--- a/include-npm-dependencies/src/app/app.functions/package-lock.json
+++ b/include-npm-dependencies/src/app/app.functions/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "example.functions",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "example.functions",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dayjs": "^1.11.5"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
+    }
+  },
+  "dependencies": {
+    "dayjs": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
+    }
+  }
+}

--- a/include-npm-dependencies/src/app/app.functions/package.json
+++ b/include-npm-dependencies/src/app/app.functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "example.functions",
+  "version": "1.0.0",
+  "description": "",
+  "main": "crm-card.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "dayjs": "^1.11.5"
+  }
+}

--- a/include-npm-dependencies/src/app/app.functions/serverless.json
+++ b/include-npm-dependencies/src/app/app.functions/serverless.json
@@ -1,0 +1,10 @@
+{
+  "runtime": "nodejs12.x",
+  "version": "1.0",
+  "appFunctions": {
+    "crm-card": {
+      "file": "crm-card.js",
+      "secrets": []
+    }
+  }
+}

--- a/include-npm-dependencies/src/app/app.json
+++ b/include-npm-dependencies/src/app/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "Include npm dependencies",
+  "description": "",
+  "scopes": [
+    "crm.objects.contacts.read",
+    "crm.objects.contacts.write"
+  ],
+  "public": false,
+  "extensions": {
+    "crm": {
+      "cards": [
+        {
+          "file": "./crm-card.json",
+          "version": 2
+        }
+      ]
+    }
+  }
+}

--- a/include-npm-dependencies/src/app/crm-card.json
+++ b/include-npm-dependencies/src/app/crm-card.json
@@ -1,0 +1,16 @@
+{
+  "type": "crm-card",
+  "version": 2,
+  "data": {
+    "title": "Include npm dependencies",
+    "fetch": {
+      "targetFunction": "crm-card",
+      "objectTypes": [
+        {
+          "name": "contacts",
+          "propertiesToSend": []
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new example to demonstrate how to include and use npm dependencies for a custom CRM card, using `day.js` as an example. The README for the project (included in this PR) has more information and instructions for use.