### PR TITLE
chore: Set up Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  extends: ["eslint:recommended", "prettier"],
+  extends: ['eslint:recommended', 'prettier'],
   env: {
     node: true,
     commonjs: true,
@@ -8,7 +8,7 @@ module.exports = {
   },
   overrides: [],
   parserOptions: {
-    ecmaVersion: "latest",
+    ecmaVersion: 'latest',
   },
   rules: {},
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,14 @@
 module.exports = {
-  "root": true,
-  "extends": [
-    "eslint:recommended",
-  ],
-  "env": {
-    "node": true,
-    "commonjs": true,
-    "es2021": true
+  root: true,
+  extends: ["eslint:recommended", "prettier"],
+  env: {
+    node: true,
+    commonjs: true,
+    es2021: true,
   },
-  "overrides": [
-  ],
-  "parserOptions": {
-    "ecmaVersion": "latest"
+  overrides: [],
+  parserOptions: {
+    ecmaVersion: "latest",
   },
-  "rules": {
-  }
-}
+  rules: {},
+};

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a bug in one of the examples
-title: "[Bug]"
+title: '[Bug]'
 labels: new-bug
 ---
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# License file
+LICENSE.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,3 @@
 {
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "semi": true,
   "singleQuote": true
 }

--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ ESLint is included in the root of this repository for ease of development. You c
 ```
 npx eslint .
 ```
-

--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ Access to these custom CRM cards is part of an ongoing beta, and more examples w
 
 ## Tools available in this repository
 
-ESLint is included in the root of this repository for ease of development. You can choose to use it yourself or not. The usage of ESLint in this repository can also serve as an example of how to set them up in your own directory of HubSpot developer projects if you so choose.
+ESLint and Prettier are included in the root of this repository for ease of development. You can choose whether or not to use them yourself. The usage of ESLint and Prettier in this repository can also serve as an example of how to set them up in your own directory of HubSpot developer projects if you so choose.
 
 ### ESLint
 
-[ESLint](https://www.npmjs.com/package/eslint) is a common, open-source linting tool for JavaScript code. To check for any eslint errors, use the following command:
+[ESLint](https://eslint.org/) is a common, open-source linting tool for JavaScript code. To check for any ESLint errors, use the following command:
 
 ```
 npx eslint .
+```
+
+### Prettier
+
+[Prettier](https://prettier.io/) is an opinionated code formatter. This tool helps developers spend more time coding, and less time on adjusting code style.
+
+Prettier can be set up to run in your editor each time you save a file. Prettier can also be run through the CLI, using the following command:
+
+```
+npx prettier --write .
 ```

--- a/display-iframe/README.md
+++ b/display-iframe/README.md
@@ -7,6 +7,7 @@ Displays a button to open a modal dialog with an iframe that displays the conten
 ## How to use
 
 This project can be used as-is in a HubSpot account by:
+
 1. Cloning this repository
 2. `cd display-iframe`
 3. `hs project upload`

--- a/display-iframe/src/app/app.functions/crm-card.js
+++ b/display-iframe/src/app/app.functions/crm-card.js
@@ -3,7 +3,7 @@ exports.main = async (context, sendResponse) => {
     sections: [
       {
         type: 'text',
-        text: 'Clicking the button will open a modal dialog with an iframe that displays the content at the provided URL.'
+        text: 'Clicking the button will open a modal dialog with an iframe that displays the content at the provided URL.',
       },
       {
         type: 'button',
@@ -13,7 +13,7 @@ exports.main = async (context, sendResponse) => {
           // Width and height of the iframe (in pixels)
           width: 1000,
           height: 800,
-          uri: 'https://product.hubspot.com/blog'
+          uri: 'https://product.hubspot.com/blog',
         },
       },
     ],

--- a/display-iframe/src/app/app.json
+++ b/display-iframe/src/app/app.json
@@ -1,10 +1,7 @@
 {
   "name": "Display iframe",
   "description": "",
-  "scopes": [
-    "crm.objects.contacts.read",
-    "crm.objects.contacts.write"
-  ],
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
   "public": false,
   "extensions": {
     "crm": {

--- a/include-npm-dependencies/README.md
+++ b/include-npm-dependencies/README.md
@@ -5,6 +5,7 @@
 ## How to use
 
 This project can be used as-is in a HubSpot account by:
+
 1. Cloning this repository
 2. `cd include-npm-dependencies`
 3. `hs project upload`
@@ -12,6 +13,7 @@ This project can be used as-is in a HubSpot account by:
 ## How it works
 
 To add an npm dependency to a project, there must be a `package.json` file in the `src/app/app.functions/` folder with an npm package specified in the `dependencies` object.
+
 1. `cd include-npm-dependencies/src/app/app.functions/`
 2. Run `npm init`. This `npm init` command will walk through the creation of the `package.json` file.
 3. Next, an npm dependency can be included using `npm install`. Example: `npm install dayjs` installs the [`dayjs` npm package](https://www.npmjs.com/package/dayjs) as a dependency, and adds it to the `dependencies` object in the `package.json`.

--- a/include-npm-dependencies/src/app/app.functions/crm-card.js
+++ b/include-npm-dependencies/src/app/app.functions/crm-card.js
@@ -6,12 +6,12 @@ exports.main = async (context, sendResponse) => {
       {
         type: 'text',
         format: 'markdown',
-        text: 'This project demonstrates how to include and use an npm dependency, using [day.js](https://www.npmjs.com/package/dayjs) as an example.'
+        text: 'This project demonstrates how to include and use an npm dependency, using [day.js](https://www.npmjs.com/package/dayjs) as an example.',
       },
       {
         type: 'text',
-        text: `Date formatting with day.js: ${dayjs().format('M/D/YYYY')}`
-      }
+        text: `Date formatting with day.js: ${dayjs().format('M/D/YYYY')}`,
+      },
     ],
   });
 };

--- a/include-npm-dependencies/src/app/app.json
+++ b/include-npm-dependencies/src/app/app.json
@@ -1,10 +1,7 @@
 {
   "name": "Include npm dependencies",
   "description": "",
-  "scopes": [
-    "crm.objects.contacts.read",
-    "crm.objects.contacts.write"
-  ],
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
   "public": false,
   "extensions": {
     "crm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "ui-extensions-examples",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
-        "eslint": "^8.22.0"
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "prettier": "2.7.1"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -377,6 +379,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -1010,6 +1024,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1552,6 +1581,13 @@
         "v8-compile-cache": "^2.0.3"
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -2023,6 +2059,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "homepage": "https://github.com/HubSpot/ui-extensions-examples#readme",
   "devDependencies": {
-    "eslint": "^8.22.0"
+    "eslint": "^8.22.0",
+    "eslint-config-prettier": "^8.5.0",
+    "prettier": "2.7.1"
   }
 }

--- a/success-and-error-banners/README.md
+++ b/success-and-error-banners/README.md
@@ -9,6 +9,7 @@ For the purposes of this example, the GET request randomly succeeds or fails eac
 ## How to use
 
 This project can be used as-is in a HubSpot account by:
+
 1. Cloning this repository
 2. `cd success-and-error-banners`
 3. `hs project upload`

--- a/success-and-error-banners/src/app/app.functions/action-feedback-banner.js
+++ b/success-and-error-banners/src/app/app.functions/action-feedback-banner.js
@@ -4,7 +4,9 @@ const axios = require('axios');
 exports.main = async (context, sendResponse) => {
   // Randomly choose between a valid and invalid URL to display for success and error demonstration purposes
   const isValidEndpoint = Math.round(Math.random());
-  const endpoint = isValidEndpoint ? 'https://www.hubspot.com' : 'https://www.hubspot.com/doesnotexist';
+  const endpoint = isValidEndpoint
+    ? 'https://www.hubspot.com'
+    : 'https://www.hubspot.com/doesnotexist';
 
   try {
     // Arbitrary request against an endpoint
@@ -14,16 +16,16 @@ exports.main = async (context, sendResponse) => {
     sendResponse({
       message: {
         type: 'SUCCESS',
-        body: 'Action was successful'
-      }
+        body: 'Action was successful',
+      },
     });
   } catch (error) {
     // Creates an error feedback banner when it catches an error
     sendResponse({
       message: {
         type: 'ERROR',
-        body: `Error: ${error.message}`
-      }
+        body: `Error: ${error.message}`,
+      },
     });
   }
 };

--- a/success-and-error-banners/src/app/app.functions/crm-card.js
+++ b/success-and-error-banners/src/app/app.functions/crm-card.js
@@ -4,14 +4,14 @@ exports.main = async (context, sendResponse) => {
     sections: [
       {
         type: 'text',
-        text: "This button will display a success or error banner to indicate the result of the button's action."
+        text: "This button will display a success or error banner to indicate the result of the button's action.",
       },
       {
         type: 'button',
         text: 'Show feedback message',
         onClick: {
           type: 'SERVERLESS_ACTION_HOOK',
-          serverlessFunction: 'action-feedback-banner'
+          serverlessFunction: 'action-feedback-banner',
         },
       },
     ],

--- a/success-and-error-banners/src/app/app.json
+++ b/success-and-error-banners/src/app/app.json
@@ -1,10 +1,7 @@
 {
   "name": "Success and error banners",
   "description": "",
-  "scopes": [
-    "crm.objects.contacts.read",
-    "crm.objects.contacts.write"
-  ],
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
   "public": false,
   "extensions": {
     "crm": {


### PR DESCRIPTION
This PR sets up Prettier for this repository, includes [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier#installation) to prevent collisions between ESLint and Prettier, and runs the existing files through it (excluding the generated LICENSE.md file and the other files that are by default excluded by Prettier, like anything in `node_modules/`). It also adds a brief explanation of Prettier and how to use it if one so chooses to the README.