### PR TITLE
feat(simple-form): Create example of a simple form

### DIFF
--- a/simple-form/.gitignore
+++ b/simple-form/.gitignore
@@ -1,0 +1,20 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# dotenv environment variables file
+.env
+.env.test
+
+# Serverless directories
+.serverless/
+
+# HubSpot config file
+hubspot.config.yml

--- a/simple-form/README.md
+++ b/simple-form/README.md
@@ -1,0 +1,11 @@
+# simple-form
+
+Displays a simple form with a text input and a submit button that, when pressed, passes the form data to the serverless function through the `context.event.payload.formState` and displays the user inputted data in a banner.
+
+## How to use
+
+This project can be used as-is in a HubSpot account by:
+
+1. Cloning this repository
+2. `cd simple-form`
+3. `hs project upload`

--- a/simple-form/README.md
+++ b/simple-form/README.md
@@ -2,6 +2,8 @@
 
 Displays a simple form with a text input and a submit button that, when pressed, passes the form data to the serverless function through the `context.event.payload.formState` and displays the user inputted data in a banner.
 
+![simple-form-example](https://user-images.githubusercontent.com/5553591/185697570-f6308601-80b5-43c2-a8ab-0f252a9b4c4f.gif)
+
 ## How to use
 
 This project can be used as-is in a HubSpot account by:

--- a/simple-form/hsproject.json
+++ b/simple-form/hsproject.json
@@ -1,0 +1,4 @@
+{
+  "name": "simple-form",
+  "srcDir": "src"
+}

--- a/simple-form/src/app/app.functions/crm-card.js
+++ b/simple-form/src/app/app.functions/crm-card.js
@@ -1,0 +1,42 @@
+exports.main = async (context, sendResponse) => {
+  const { event } = context;
+
+  if (event && event.type === 'SUBMIT') {
+    const { example_input } = event.payload.formState;
+    sendResponse({
+      message: {
+        type: 'SUCCESS',
+        body: `Form submit was successful. Input's value: ${example_input}`,
+      },
+    });
+  }
+
+  sendResponse({
+    sections: [
+      {
+        type: 'text',
+        text: "This example displays a simple form with a text input and a submit button. Inputting data into the field and clicking the submit button shows a banner with the user's input.",
+      },
+      {
+        type: 'form',
+        content: [
+          {
+            type: 'input',
+            name: 'example_input',
+            inputType: 'text',
+            label: 'Example input field',
+            initialValue: 'Default value of the input field',
+          },
+          {
+            type: 'button',
+            text: 'Submit form',
+            onClick: {
+              type: 'SUBMIT',
+              serverlessFunction: 'crm-card',
+            },
+          },
+        ],
+      },
+    ],
+  });
+};

--- a/simple-form/src/app/app.functions/serverless.json
+++ b/simple-form/src/app/app.functions/serverless.json
@@ -1,0 +1,10 @@
+{
+  "runtime": "nodejs12.x",
+  "version": "1.0",
+  "appFunctions": {
+    "crm-card": {
+      "file": "crm-card.js",
+      "secrets": []
+    }
+  }
+}

--- a/simple-form/src/app/app.json
+++ b/simple-form/src/app/app.json
@@ -1,0 +1,16 @@
+{
+  "name": "Simple form",
+  "description": "",
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
+  "public": false,
+  "extensions": {
+    "crm": {
+      "cards": [
+        {
+          "file": "./crm-card.json",
+          "version": 2
+        }
+      ]
+    }
+  }
+}

--- a/simple-form/src/app/crm-card.json
+++ b/simple-form/src/app/crm-card.json
@@ -1,0 +1,16 @@
+{
+  "type": "crm-card",
+  "version": 2,
+  "data": {
+    "title": "Simple form",
+    "fetch": {
+      "targetFunction": "crm-card",
+      "objectTypes": [
+        {
+          "name": "contacts",
+          "propertiesToSend": []
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Displays a simple form with a text input and a submit button that, when pressed, passes the form data to the serverless function through the `context.event.payload.formState` and displays the user inputted data in a banner.

![simple-form-example](https://user-images.githubusercontent.com/5553591/185697570-f6308601-80b5-43c2-a8ab-0f252a9b4c4f.gif)
