### PR TITLE
Update examples to use Node 16.x

### DIFF
--- a/display-iframe/src/app/app.functions/serverless.json
+++ b/display-iframe/src/app/app.functions/serverless.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs12.x",
+  "runtime": "nodejs16.x",
   "version": "1.0",
   "appFunctions": {
     "crm-card": {

--- a/include-npm-dependencies/src/app/app.functions/serverless.json
+++ b/include-npm-dependencies/src/app/app.functions/serverless.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs12.x",
+  "runtime": "nodejs16.x",
   "version": "1.0",
   "appFunctions": {
     "crm-card": {

--- a/simple-form/src/app/app.functions/serverless.json
+++ b/simple-form/src/app/app.functions/serverless.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs12.x",
+  "runtime": "nodejs16.x",
   "version": "1.0",
   "appFunctions": {
     "crm-card": {

--- a/success-and-error-banners/src/app/app.functions/serverless.json
+++ b/success-and-error-banners/src/app/app.functions/serverless.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs12.x",
+  "runtime": "nodejs16.x",
   "version": "1.0",
   "appFunctions": {
     "crm-card": {


### PR DESCRIPTION
Since AWS has [announced end of support for `nodejs12.x`](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) starting in May 2023, we're updating our examples to use `nodejs16.x`.

These examples should continue to function as-is.