### PR TITLE
feat: Add eslint support for contact-duplicate example

### DIFF
--- a/contact-duplicate/src/app/extensions/.eslintrc
+++ b/contact-duplicate/src/app/extensions/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "root": true,
+  "extends": [
+    "@hubspot/ui-extensions",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "plugins": ["@typescript-eslint"],
+  "ignorePatterns": ["dist"]
+}

--- a/contact-duplicate/src/app/extensions/Extension.tsx
+++ b/contact-duplicate/src/app/extensions/Extension.tsx
@@ -61,7 +61,7 @@ const Extension = ({ runServerless, context }: ExtensionProps) => {
         setError(resp.message); // Set error message from response
       }
     });
-  }, [runServerless]); // Dependency array is empty, so this effect runs only once
+  }, [runServerless]);
 
   // Function to handle contact duplication
   const duplicateContact = () => {

--- a/contact-duplicate/src/app/extensions/Extension.tsx
+++ b/contact-duplicate/src/app/extensions/Extension.tsx
@@ -42,7 +42,7 @@ export interface AssociationsGQL {
 // Define the Extension component, taking in runServerless and context as props
 const Extension = ({ runServerless, context }: ExtensionProps) => {
   const [loading, setLoading] = useState(true);
-  const [associations, setAssocaitions] = useState<AssociationsGQL>();
+  const [associations, setAssociations] = useState<AssociationsGQL>();
   const [email, setEmail] = useState('');
   const [url, setUrl] = useState('');
   const [error, setError] = useState('');
@@ -56,7 +56,7 @@ const Extension = ({ runServerless, context }: ExtensionProps) => {
       setLoading(false); // End loading state
       if (resp.status === 'SUCCESS') {
         // Set associations with response data
-        setAssocaitions(resp.response.associations as AssociationsGQL);
+        setAssociations(resp.response.associations as AssociationsGQL);
       } else {
         setError(resp.message); // Set error message from response
       }

--- a/contact-duplicate/src/app/extensions/Extension.tsx
+++ b/contact-duplicate/src/app/extensions/Extension.tsx
@@ -6,7 +6,6 @@ import {
   Context,
   DescriptionList,
   DescriptionListItem,
-  Divider,
   Input,
   Link,
   LoadingSpinner,
@@ -62,7 +61,7 @@ const Extension = ({ runServerless, context }: ExtensionProps) => {
         setError(resp.message); // Set error message from response
       }
     });
-  }, []); // Dependency array is empty, so this effect runs only once
+  }, [runServerless]); // Dependency array is empty, so this effect runs only once
 
   // Function to handle contact duplication
   const duplicateContact = () => {
@@ -77,7 +76,7 @@ const Extension = ({ runServerless, context }: ExtensionProps) => {
         const contact = resp.response;
         // Set the URL to the newly created contact
         setUrl(
-          `https://app.hubspot.com/contacts/${context.portal.id}/contact/${contact.id}`,
+          `https://app.hubspot.com/contacts/${context.portal.id}/contact/${contact.id}`
         );
       } else {
         setError(resp.message); // Set error message from response

--- a/contact-duplicate/src/app/extensions/Extension.tsx
+++ b/contact-duplicate/src/app/extensions/Extension.tsx
@@ -3,16 +3,16 @@ import React, { useEffect, useState } from 'react';
 import {
   Alert,
   Button,
-  Context,
   DescriptionList,
   DescriptionListItem,
   Input,
   Link,
   LoadingSpinner,
-  ServerlessFuncRunner,
   Text,
   Flex,
   hubspot,
+  type Context,
+  type ServerlessFuncRunner,
 } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "lint": "eslint . --ext .tsx,.ts",
     "lint:fix": "eslint . --ext .tsx,.ts --fix",
-    "typecheck": "tsc --noEmit --jsx react-jsx --esModuleInterop --lib WebWorker --lib esnext --skipLibCheck ./**/*.ts[x]",
-    "check": "npm run lint && npm run typecheck"
+    "check:types": "tsc --noEmit --jsx react-jsx --esModuleInterop --lib WebWorker --lib esnext --skipLibCheck Extension.tsx",
+    "check": "npm run lint && npm run check:types"
   },
   "devDependencies": {
     "@hubspot/eslint-config-ui-extensions": "^0.7.2",

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "lint": "eslint . --ext .tsx,.ts",
-    "lint:fix": "eslint . --ext .tsx,.ts --fix"
+    "lint:fix": "eslint . --ext .tsx,.ts --fix",
+    "check": "npm run lint && tsc"
   },
   "devDependencies": {
     "@hubspot/eslint-config-ui-extensions": "^0.7.2",

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "lint": "eslint . --ext .tsx,.ts",
     "lint:fix": "eslint . --ext .tsx,.ts --fix",
-    "check": "npm run lint && tsc"
+    "typecheck": "tsc --noEmit --jsx react-jsx --esModuleInterop --lib WebWorker --lib esnext --skipLibCheck .**/*.ts[x]",
+    "check": "npm run lint && npm run typecheck"
   },
   "devDependencies": {
     "@hubspot/eslint-config-ui-extensions": "^0.7.2",

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -6,5 +6,14 @@
   "dependencies": {
     "@hubspot/ui-extensions": "latest",
     "react": "^18.2.0"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .tsx,.ts"
+  },
+  "devDependencies": {
+    "@hubspot/eslint-config-ui-extensions": "^0.7.2",
+    "@typescript-eslint/eslint-plugin": "^6.4.0",
+    "@typescript-eslint/parser": "^6.4.0",
+    "eslint": "^8.47.0"
   }
 }

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -8,7 +8,8 @@
     "react": "^18.2.0"
   },
   "scripts": {
-    "lint": "eslint . --ext .tsx,.ts"
+    "lint": "eslint . --ext .tsx,.ts",
+    "lint:fix": "eslint . --ext .tsx,.ts --fix"
   },
   "devDependencies": {
     "@hubspot/eslint-config-ui-extensions": "^0.7.2",

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -15,6 +15,7 @@
     "@hubspot/eslint-config-ui-extensions": "^0.7.2",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
-    "eslint": "^8.47.0"
+    "eslint": "^8.47.0",
+    "typescript": "^5.1.6"
   }
 }

--- a/contact-duplicate/src/app/extensions/package.json
+++ b/contact-duplicate/src/app/extensions/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint . --ext .tsx,.ts",
     "lint:fix": "eslint . --ext .tsx,.ts --fix",
-    "typecheck": "tsc --noEmit --jsx react-jsx --esModuleInterop --lib WebWorker --lib esnext --skipLibCheck .**/*.ts[x]",
+    "typecheck": "tsc --noEmit --jsx react-jsx --esModuleInterop --lib WebWorker --lib esnext --skipLibCheck ./**/*.ts[x]",
     "check": "npm run lint && npm run typecheck"
   },
   "devDependencies": {


### PR DESCRIPTION
Test of integrating [`@hubspot/eslint-config-ui-extensions`](https://www.npmjs.com/package/@hubspot/eslint-config-ui-extensions) package to provide better linting support for examples.