### PR TITLE
fix: Remove ; from post-install to support powershell

### DIFF
--- a/contact-duplicate/package.json
+++ b/contact-duplicate/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Basic example of a UI Extension built with HubSpot's React developer tools",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install; cd ../app.functions && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "author": "HubSpot",

--- a/example-meal-order/package.json
+++ b/example-meal-order/package.json
@@ -2,7 +2,7 @@
   "name": "hubspot-meal-order-project",
   "version": "0.1.0",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install; cd ../app.functions && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "author": "HubSpot",

--- a/with-crm-components/package.json
+++ b/with-crm-components/package.json
@@ -4,7 +4,7 @@
   "description": "UI extension example using CRM components",
   "main": "index.js",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {


### PR DESCRIPTION
Running an `npm install` from the project root was causing a syntax error in powershell because `npm install;` was parsed as `npm` and `install;`, so `npm` would rightfully error saying `install;` is not a valid command.