### PR TITLE
feat: PRIVATE_APP_ACCESS_TOKEN is no longer needed in `.env` files

### DIFF
--- a/company-proximity-navigator/src/app/app.functions/.env.sample
+++ b/company-proximity-navigator/src/app/app.functions/.env.sample
@@ -1,17 +1,13 @@
 # FOR LOCAL DEVELOPMENT ONLY: Use .env files to configure your
-# environment during local development.
+# environment during local development. If your app functions require
+# secrets, create a file named ".env" in the app.functions/ directory
+# and supply the secrets as shown below. Do not commit this file for
+# source control.
 #
 # NOTE: Do not add your PRIVATE_APP_ACCESS_TOKEN to your secrets or
-# any other configs, it's provided automatically for deployed apps
-
-# Find your token by:
-# - Visiting https://app.hubspot.com/l/private-apps
-# - Choose the portal you're using for active development
-# - On the "Private Apps" screen, select your app, then click the "Auth" tab
-# - Click "Show Token", then "Copy"
-# - Paste that value between the quotes below ⬇️
-PRIVATE_APP_ACCESS_TOKEN="<placeholder>"
-
+# any other configs, it's provided automatically for deployed apps.
+# Do not add it in the .env file; it will be ignored.
+EXAMPLE_SECRET_NAME="example secret value"
 
 # Obtain Mapbox access token using the following guide: https://docs.mapbox.com/help/getting-started/access-tokens/
 MAPBOX_ACCESS_TOKEN="<placeholder>"

--- a/contact-duplicate/src/app/app.functions/.env.sample
+++ b/contact-duplicate/src/app/app.functions/.env.sample
@@ -1,13 +1,10 @@
 # FOR LOCAL DEVELOPMENT ONLY: Use .env files to configure your
-# environment during local development.
+# environment during local development. If your app functions require
+# secrets, create a file named ".env" in the app.functions/ directory
+# and supply the secrets as shown below. Do not commit this file for
+# source control.
 #
 # NOTE: Do not add your PRIVATE_APP_ACCESS_TOKEN to your secrets or
-# any other configs, it's provided automatically for deployed apps
-
-# Find your token by:
-# - Visiting https://app.hubspot.com/l/private-apps
-# - Choose the portal you're using for active development
-# - On the "Private Apps" screen, select your app, then click the "Auth" tab
-# - Click "Show Token", then "Copy"
-# - Paste that value between the quotes below ⬇️
-PRIVATE_APP_ACCESS_TOKEN="<placeholder>"
+# any other configs, it's provided automatically for deployed apps.
+# Do not add it in the .env file; it will be ignored.
+EXAMPLE_SECRET_NAME="example secret value"

--- a/deals-summary/src/app/app.functions/.env.sample
+++ b/deals-summary/src/app/app.functions/.env.sample
@@ -1,13 +1,10 @@
 # FOR LOCAL DEVELOPMENT ONLY: Use .env files to configure your
-# environment during local development.
+# environment during local development. If your app functions require
+# secrets, create a file named ".env" in the app.functions/ directory
+# and supply the secrets as shown below. Do not commit this file for
+# source control.
 #
 # NOTE: Do not add your PRIVATE_APP_ACCESS_TOKEN to your secrets or
-# any other configs, it's provided automatically for deployed apps
-
-# Find your token by:
-# - Visiting https://app.hubspot.com/l/private-apps
-# - Choose the portal you're using for active development
-# - On the "Private Apps" screen, select your app, then click the "Auth" tab
-# - Click "Show Token", then "Copy"
-# - Paste that value between the quotes below ⬇️
-PRIVATE_APP_ACCESS_TOKEN="<placeholder>"
+# any other configs, it's provided automatically for deployed apps.
+# Do not add it in the .env file; it will be ignored.
+EXAMPLE_SECRET_NAME="example secret value"

--- a/quote-generator/src/app/app.functions/.env.sample
+++ b/quote-generator/src/app/app.functions/.env.sample
@@ -1,13 +1,10 @@
 # FOR LOCAL DEVELOPMENT ONLY: Use .env files to configure your
-# environment during local development.
+# environment during local development. If your app functions require
+# secrets, create a file named ".env" in the app.functions/ directory
+# and supply the secrets as shown below. Do not commit this file for
+# source control.
 #
 # NOTE: Do not add your PRIVATE_APP_ACCESS_TOKEN to your secrets or
-# any other configs, it's provided automatically for deployed apps
-
-# Find your token by:
-# - Visiting https://app.hubspot.com/l/private-apps
-# - Choose the portal you're using for active development
-# - On the "Private Apps" screen, select your app, then click the "Auth" tab
-# - Click "Show Token", then "Copy"
-# - Paste that value between the quotes below ⬇️
-PRIVATE_APP_ACCESS_TOKEN="<placeholder>"
+# any other configs, it's provided automatically for deployed apps.
+# Do not add it in the .env file; it will be ignored.
+EXAMPLE_SECRET_NAME="example secret value"


### PR DESCRIPTION
With the upcoming npm updates, `PRIVATE_APP_ACCESS_TOKEN` will no longer be needed for local execution of app functions. Update instructions in `.env` sample files to reflect this change.