### PR TITLE
chore: Remove `@hubspot/cli` as a dep since it will be installed globally

### DIFF
--- a/flex-and-box/package.json
+++ b/flex-and-box/package.json
@@ -7,7 +7,5 @@
   },
   "author": "HubSpot",
   "license": "MIT",
-  "dependencies": {
-    "@hubspot/cli": "^5.0.1"
-  }
+  "dependencies": {}
 }

--- a/flex-and-box/src/app/extensions/package.json
+++ b/flex-and-box/src/app/extensions/package.json
@@ -4,7 +4,6 @@
   "author": "HubSpot",
   "license": "MIT",
   "dependencies": {
-    "@hubspot/cli": "^5.0.1",
     "@hubspot/ui-extensions": "latest",
     "react": "^18.2.0"
   }


### PR DESCRIPTION
Removing `@hubspot/cli` as a local dependency because we need it to be installed globally on the system