### PR TITLE
chore: Add script to check version of `hs` installed

### DIFF
--- a/company-proximity-navigator/package.json
+++ b/company-proximity-navigator/package.json
@@ -2,7 +2,7 @@
   "name": "company-proximity-navigator",
   "version": "0.1.0",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install"
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install && cd ../../.. && ../scripts/check-hs-version.js"
   },
   "author": "HubSpot",
   "license": "MIT"

--- a/contact-duplicate/package.json
+++ b/contact-duplicate/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Basic example of a UI Extension built with HubSpot's React developer tools",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install && cd ../../.. && ../scripts/check-hs-version.js",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "author": "HubSpot",

--- a/deals-summary/package.json
+++ b/deals-summary/package.json
@@ -2,7 +2,7 @@
   "name": "deals-summary",
   "version": "0.1.0",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install"
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install && cd ../../.. && ../scripts/check-hs-version.js"
   },
   "author": "HubSpot",
   "license": "MIT"

--- a/example-meal-order/package.json
+++ b/example-meal-order/package.json
@@ -2,7 +2,7 @@
   "name": "hubspot-meal-order-project",
   "version": "0.1.0",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install && cd ../../.. && ../scripts/check-hs-version.js",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "author": "HubSpot",

--- a/flex-and-box/package.json
+++ b/flex-and-box/package.json
@@ -2,7 +2,7 @@
   "name": "flex-and-box",
   "version": "0.1.0",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../../.. && ../scripts/check-hs-version.js",
     "build": "npm run build --prefix ./src/app/extensions/"
   },
   "author": "HubSpot",

--- a/quote-generator/package.json
+++ b/quote-generator/package.json
@@ -2,7 +2,7 @@
   "name": "shuttle-bus-quotes",
   "version": "0.1.0",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install"
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install && cd ../../.. && ../scripts/check-hs-version.js"
   },
   "author": "HubSpot",
   "license": "MIT"

--- a/scripts/check-hs-version.js
+++ b/scripts/check-hs-version.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+const FgRed = '\x1b[31m';
+const Reset = '\x1b[0m';
+const FgGreen = '\x1b[32m';
+
+function exitWithError(...args) {
+  console.error(FgRed, ...args, Reset);
+  process.exit(1);
+}
+
+function exitWithSuccess() {
+  console.log(
+    FgGreen,
+    'The version of @hubspot/cli installed is correct!\n',
+    Reset
+  );
+  process.exit(0);
+}
+const { execSync } = require('child_process');
+const minRequiredVersion = {
+  major: 5,
+  minor: 0,
+  patch: 0,
+};
+try {
+  execSync('hs', { stdio: 'pipe' });
+} catch (e) {
+  exitWithError(
+    'You do not have the HubSpot cli installed, please run `npm install -g @hubspot/cli` to install it.\n'
+  );
+}
+
+function meetsMinimumRequiredVersion(major, minor, patch) {
+  if (major < minRequiredVersion.major) {
+    return false;
+  } else if (major > minRequiredVersion.major) {
+    return true;
+  }
+
+  if (minor < minRequiredVersion.minor) {
+    return false;
+  } else if (minor > minRequiredVersion.major) {
+    return true;
+  }
+
+  if (patch < minRequiredVersion.patch) {
+    return false;
+  }
+
+  return true;
+}
+
+try {
+  const version = execSync('hs --version');
+  const [major, minor, patch] = version
+    .toString()
+    .split('.')
+    .map((bit) => Number(bit));
+  const meetsMinRequirement = meetsMinimumRequiredVersion(major, minor, patch);
+  if (!meetsMinRequirement) {
+    const minVersionString = `${minRequiredVersion.major}.${minRequiredVersion.minor}.${minRequiredVersion.patch}`;
+    const updateMessage = `This project requires a minimum version of ${minVersionString}, please update your @hubspot/cli version.  Your current installed version is ${version}\n`;
+    exitWithError(updateMessage);
+  }
+} catch (e) {
+  exitWithError(
+    'Unable to determine which version of `@hubspot/cli` is installed, '
+  );
+}
+
+exitWithSuccess();

--- a/scripts/check-hs-version.js
+++ b/scripts/check-hs-version.js
@@ -3,6 +3,13 @@ const FgRed = '\x1b[31m';
 const Reset = '\x1b[0m';
 const FgGreen = '\x1b[32m';
 
+const { execSync } = require('child_process');
+const minRequiredVersion = {
+  major: 5,
+  minor: 0,
+  patch: 0,
+};
+
 function exitWithError(...args) {
   console.error(FgRed, ...args, Reset);
   process.exit(1);
@@ -15,19 +22,6 @@ function exitWithSuccess() {
     Reset
   );
   process.exit(0);
-}
-const { execSync } = require('child_process');
-const minRequiredVersion = {
-  major: 5,
-  minor: 0,
-  patch: 0,
-};
-try {
-  execSync('hs', { stdio: 'pipe' });
-} catch (e) {
-  exitWithError(
-    'You do not have the HubSpot cli installed, please run `npm install -g @hubspot/cli` to install it.\n'
-  );
 }
 
 function meetsMinimumRequiredVersion(major, minor, patch) {
@@ -48,6 +42,14 @@ function meetsMinimumRequiredVersion(major, minor, patch) {
   }
 
   return true;
+}
+
+try {
+  execSync('hs', { stdio: 'pipe' });
+} catch (e) {
+  exitWithError(
+    'You do not have the HubSpot cli installed, please run `npm install -g @hubspot/cli` to install it.\n'
+  );
 }
 
 try {

--- a/with-crm-components/package.json
+++ b/with-crm-components/package.json
@@ -4,7 +4,7 @@
   "description": "UI extension example using CRM components",
   "main": "index.js",
   "scripts": {
-    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install",
+    "postinstall": "cd ./src/app/extensions/ && npm install && cd ../app.functions && npm install && cd ../../.. && ../scripts/check-hs-version.js",
     "dev": "npm run dev --prefix ./src/app/extensions/"
   },
   "repository": {


### PR DESCRIPTION
This PR:
- Adds a script that checks that the `hs` command is installed and meets a minimum version
- Runs this script on the post install step