### PR TITLE
feat: Update examples to use new API for calling app functions

### DIFF
--- a/company-proximity-navigator/src/app/app.functions/getCompaniesWithDistanceBatch.js
+++ b/company-proximity-navigator/src/app/app.functions/getCompaniesWithDistanceBatch.js
@@ -20,7 +20,7 @@ const PROPERTIES_TO_FETCH = [
 
 // Entry function of this module, it fetches batch of companies and calculates distance to the current company record
 exports.main = async (context = {}) => {
-  const { batchSize } = context.event.payload;
+  const { batchSize } = context.parameters;
 
   const companies = await getCompaniesBatch({
     hubspotClient: new hubspot.Client({

--- a/company-proximity-navigator/src/app/extensions/NearestCompanies.jsx
+++ b/company-proximity-navigator/src/app/extensions/NearestCompanies.jsx
@@ -4,15 +4,14 @@ import { CompaniesWithDistanceTable } from './components/CompaniesWithDistanceTa
 import { hubspot } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ actions, context, runServerlessFunction }) => (
+hubspot.extend(({ actions, context }) => (
   <NearestCompanies
-    runServerless={runServerlessFunction}
     context={context}
     fetchProperties={actions.fetchCrmObjectProperties}
   />
 ));
 
-const NearestCompanies = ({ context, runServerless, fetchProperties }) => {
+const NearestCompanies = ({ context, fetchProperties }) => {
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
   const [nearestCompaniesSorted, setNearestCompaniesSorted] = useState([]);
@@ -21,25 +20,26 @@ const NearestCompanies = ({ context, runServerless, fetchProperties }) => {
   useEffect(() => {
     async function fetchCompaniesWithDistanceBatch() {
       setLoading(true);
-      // Request companies batch from serverless function
-      const companiesServerlessResponse = await runServerless({
-        name: 'getCompaniesWithDistanceBatch',
-        propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
-        payload: { batchSize: 30 },
-      });
-      if (companiesServerlessResponse.status == 'SUCCESS') {
-        const { companies } = companiesServerlessResponse.response;
+      try {
+        // Request companies batch from serverless function
+        const { companies } = await hubspot.serverless(
+          'getCompaniesWithDistanceBatch',
+          {
+            propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
+            payload: { batchSize: 30 },
+          },
+        );
         // Sort companies by distance
         setNearestCompaniesSorted(
-          companies.sort((c1, c2) => c1.distance - c2.distance)
+          companies.sort((c1, c2) => c1.distance - c2.distance),
         );
-      } else {
-        setErrorMessage(companiesServerlessResponse.message);
+      } catch (error) {
+        setErrorMessage(error.message);
       }
       setLoading(false);
     }
     fetchCompaniesWithDistanceBatch();
-  }, [fetchProperties, runServerless]);
+  }, [fetchProperties]);
 
   if (errorMessage) {
     // If there's an error, show an alert

--- a/company-proximity-navigator/src/app/extensions/NearestCompanies.jsx
+++ b/company-proximity-navigator/src/app/extensions/NearestCompanies.jsx
@@ -26,7 +26,7 @@ const NearestCompanies = ({ context, fetchProperties }) => {
           'getCompaniesWithDistanceBatch',
           {
             propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
-            payload: { batchSize: 30 },
+            parameters: { batchSize: 30 },
           },
         );
         // Sort companies by distance

--- a/company-proximity-navigator/src/app/extensions/TopValueCompanies.jsx
+++ b/company-proximity-navigator/src/app/extensions/TopValueCompanies.jsx
@@ -29,7 +29,7 @@ const TopValueCompanies = ({ context }) => {
         'getCompaniesWithDistanceBatch',
         {
           propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
-          payload: { batchSize: companiesBatchSize },
+          parameters: { batchSize: companiesBatchSize },
         },
       );
       setTopValueCompaniesSorted(

--- a/company-proximity-navigator/src/app/extensions/TopValueCompanies.jsx
+++ b/company-proximity-navigator/src/app/extensions/TopValueCompanies.jsx
@@ -12,11 +12,9 @@ import { CompaniesWithDistanceTable } from './components/CompaniesWithDistanceTa
 import { hubspot } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ context, runServerlessFunction }) => (
-  <TopValueCompanies context={context} runServerless={runServerlessFunction} />
-));
+hubspot.extend(({ context }) => <TopValueCompanies context={context} />);
 
-const TopValueCompanies = ({ context, runServerless }) => {
+const TopValueCompanies = ({ context }) => {
   const [topValueCompaniesSorted, setTopValueCompaniesSorted] = useState([]);
   const [radius, setRadius] = useState(50);
   const [loading, setLoading] = useState(false);
@@ -26,23 +24,24 @@ const TopValueCompanies = ({ context, runServerless }) => {
 
   const executeServerless = async () => {
     setLoading(true);
-    const companiesServerlessResponse = await runServerless({
-      name: 'getCompaniesWithDistanceBatch',
-      propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
-      payload: { batchSize: companiesBatchSize },
-    });
-    if (companiesServerlessResponse.status == 'SUCCESS') {
-      const { companies } = companiesServerlessResponse.response;
+    try {
+      const { companies } = await hubspot.serverless(
+        'getCompaniesWithDistanceBatch',
+        {
+          propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
+          payload: { batchSize: companiesBatchSize },
+        },
+      );
       setTopValueCompaniesSorted(
         companies
           .filter((company) => company.distance <= radius)
           .sort(
             (c1, c2) =>
-              c2.properties.annualrevenue - c1.properties.annualrevenue
-          )
+              c2.properties.annualrevenue - c1.properties.annualrevenue,
+          ),
       );
-    } else {
-      setErrorMessage(companiesServerlessResponse.message);
+    } catch (error) {
+      setErrorMessage(error.message);
     }
     setLoading(false);
   };

--- a/deals-summary/src/app/extensions/DealsSummary.jsx
+++ b/deals-summary/src/app/extensions/DealsSummary.jsx
@@ -9,12 +9,10 @@ import {
 import { hubspot } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ runServerlessFunction }) => (
-  <DealsSummary runServerless={runServerlessFunction} />
-));
+hubspot.extend(() => <DealsSummary />);
 
-// Define the Extension component, taking in runServerless prop
-const DealsSummary = ({ runServerless }) => {
+// Define the Extension component
+const DealsSummary = () => {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
   const [dealsCount, setDealsCount] = useState(0);
@@ -22,18 +20,13 @@ const DealsSummary = ({ runServerless }) => {
 
   useEffect(() => {
     // Request statistics data from serverless function
-    runServerless({
-      name: 'get-data',
-      propertiesToSend: ['hs_object_id'],
-    })
-      .then((serverlessResponse) => {
-        if (serverlessResponse.status == 'SUCCESS') {
-          const { response } = serverlessResponse;
-          setDealsCount(response.dealsCount);
-          setTotalAmount(response.totalAmount);
-        } else {
-          setErrorMessage(serverlessResponse.message);
-        }
+    hubspot
+      .serverless('get-data', {
+        propertiesToSend: ['hs_object_id'],
+      })
+      .then((response) => {
+        setDealsCount(response.dealsCount);
+        setTotalAmount(response.totalAmount);
       })
       .catch((error) => {
         setErrorMessage(error.message);
@@ -41,7 +34,7 @@ const DealsSummary = ({ runServerless }) => {
       .finally(() => {
         setLoading(false);
       });
-  }, [runServerless]);
+  }, []);
 
   if (loading) {
     // If loading, show a spinner

--- a/example-meal-order/src/app/extensions/OrderMealExtension.tsx
+++ b/example-meal-order/src/app/extensions/OrderMealExtension.tsx
@@ -2,13 +2,10 @@ import React from 'react';
 import { hubspot } from '@hubspot/ui-extensions';
 import { OrderMealCard } from './components/OrderMealCard';
 
-hubspot.extend<'crm.record.tab'>(
-  ({ context, runServerlessFunction, actions }) => (
-    <OrderMealCard
-      fetchCrmObjectProperties={actions.fetchCrmObjectProperties}
-      context={context}
-      runServerless={runServerlessFunction}
-      sendAlert={actions.addAlert}
-    />
-  )
-);
+hubspot.extend<'crm.record.tab'>(({ context, actions }) => (
+  <OrderMealCard
+    fetchCrmObjectProperties={actions.fetchCrmObjectProperties}
+    context={context}
+    sendAlert={actions.addAlert}
+  />
+));

--- a/example-meal-order/src/app/extensions/types.ts
+++ b/example-meal-order/src/app/extensions/types.ts
@@ -1,8 +1,7 @@
 import type {
   AddAlertAction,
-  Context,
+  CrmContext,
   FetchCrmObjectPropertiesAction,
-  ServerlessFuncRunner
 } from '@hubspot/ui-extensions';
 
 export interface MenuItem {
@@ -110,7 +109,6 @@ export interface AddonsProps {
 
 export interface OrderMealProps {
   fetchCrmObjectProperties: FetchCrmObjectPropertiesAction;
-  context: Context;
-  runServerless: ServerlessFuncRunner;
+  context: CrmContext;
   sendAlert: AddAlertAction;
 }

--- a/quote-generator/src/app/app.functions/createQuote.js
+++ b/quote-generator/src/app/app.functions/createQuote.js
@@ -9,7 +9,7 @@ const hubspotClient = new hubspot.Client({
 // Entry function of this module, it creates a quote together with line items
 exports.main = async (context = {}) => {
   const { hs_object_id } = context.propertiesToSend;
-  const { distance, sku, numberOfBuses, quoteName } = context.event.payload;
+  const { distance, sku, numberOfBuses, quoteName } = context.parameters;
 
   const product = await findProductBySKU(sku);
 

--- a/quote-generator/src/app/extensions/ShuttleBusQuotes.jsx
+++ b/quote-generator/src/app/extensions/ShuttleBusQuotes.jsx
@@ -24,11 +24,11 @@ const ShuttleBusQuotes = () => {
   const [numberOfBuses, setNumberOfBuses] = useState();
   const [loading, setLoading] = useState(false);
 
-  const generateQuote = ({ ...payload }) => {
+  const generateQuote = ({ ...parameters }) => {
     // Execute serverless function to generate a quote
     return hubspot.serverless('createQuote', {
       propertiesToSend: ['hs_object_id'],
-      payload,
+      parameters,
     });
   };
 

--- a/quote-generator/src/app/extensions/ShuttleBusQuotes.jsx
+++ b/quote-generator/src/app/extensions/ShuttleBusQuotes.jsx
@@ -14,11 +14,9 @@ const Steps = {
 };
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ runServerlessFunction }) => (
-  <ShuttleBusQuotes runServerless={runServerlessFunction} />
-));
+hubspot.extend(() => <ShuttleBusQuotes />);
 
-const ShuttleBusQuotes = ({ runServerless }) => {
+const ShuttleBusQuotes = () => {
   const [step, setStep] = useState(Steps.QuotesView);
   const [passengers, setPassengers] = useState();
   const [distance, setDistance] = useState();
@@ -28,8 +26,7 @@ const ShuttleBusQuotes = ({ runServerless }) => {
 
   const generateQuote = ({ ...payload }) => {
     // Execute serverless function to generate a quote
-    return runServerless({
-      name: 'createQuote',
+    return hubspot.serverless('createQuote', {
       propertiesToSend: ['hs_object_id'],
       payload,
     });

--- a/with-crm-components/src/app/extensions/StageTrackerExtension.tsx
+++ b/with-crm-components/src/app/extensions/StageTrackerExtension.tsx
@@ -14,21 +14,15 @@ import {
   CrmAssociationPivot,
 } from '@hubspot/ui-extensions/crm';
 
-hubspot.extend(({ context, actions, runServerlessFunction }) => (
+hubspot.extend(({ context, actions }) => (
   <Extension
     context={context}
-    runServerless={runServerlessFunction}
     fetchCrmObjectProperties={actions.fetchCrmObjectProperties}
     addAlert={actions.addAlert}
   />
 ));
 
-const Extension = ({
-  context,
-  runServerless,
-  fetchCrmObjectProperties,
-  addAlert,
-}) => {
+const Extension = ({ context, fetchCrmObjectProperties, addAlert }) => {
   const [stage, setStage] = useState<string | null>(null);
   const [showProperties, setShowProperties] = useState(true);
   const [dealId, setDealId] = useState<string | null>(null);
@@ -80,25 +74,25 @@ const Extension = ({
 
   const handleStageChange = useCallback(
     (newStage: string) => {
-      runServerless({
-        name: 'updateDeal',
-        parameters: {
-          dealId: dealId!,
-          dealStage: newStage,
-        },
-      }).then((resp: { status: string; message?: string }) => {
-        if (resp.status === 'SUCCESS') {
+      hubspot
+        .serverless('updateDeal', {
+          parameters: {
+            dealId: dealId!,
+            dealStage: newStage
+          }
+        })
+        .then(response => {
           addAlert({
             type: 'success',
-            message: 'Deal stage updated successfully',
+            message: 'Deal stage updated successfully'
           });
           setStage(newStage);
-        } else {
-          setError(resp.message || 'An error occurred');
-        }
-      });
+        })
+        .catch(error => {
+          setError(error.message || 'An error occurred');
+        });
     },
-    [dealId, addAlert, runServerless]
+    [dealId, addAlert]
   );
 
   const handlePropertyToggle = useCallback(() => {


### PR DESCRIPTION
## Description

* We are introducing a simpler API, `hubspot.serverless`, for calling app functions in `@hubspot/ui-extensions@0.8.5`.
* Note that the `runServerlessFunction` way still works. 
* See [an example](https://github.com/HubSpot/ui-extensions-examples/pull/49/commits/ed4e332c87fd311bde583b48adb09bdaf01021cb) migrating from `runServerlessFunction` to `hubspot.serverless`.

_This PR is best reviewed by commits._

## Usage

With promise syntax:
```javascript
import { hubspot } from "@hubspot/ui-extensions";

hubspot.extend(() => <Extension />);

const Extension = () => {
  const handleSubmit = () => {
    hubspot
      .serverless("func-name", {
        // options, if any (e.g., propertiesToSend or parameters)
      })
      .then((response) => {
        // handle response, which is the value returned from the function on success
      })
      .catch((error) => {
        // handle error, which is an Error object if the function failed to execute
      });
  };
  return <Button onClick={handleSubmit} label="Click me" />;
}
```

With async/await syntax:
```javascript
import { hubspot } from "@hubspot/ui-extensions";

hubspot.extend(() => <Extension />);

const Extension = () => {
  const handleSubmit = async () => {
    try {
      const response = await hubspot.serverless("func-name", {
        // options, if any (e.g., propertiesToSend or parameters)
      });
      // handle response, which is the value returned from the function on success
    } catch (error) {
      // handle error, which is an Error object if the function failed to execute
    };
  };
  return <Button onClick={handleSubmit} label="Click me" />;
}
```