### PR TITLE
Handle error when no company address is specified

### DIFF
--- a/mapbox-api/src/app/app.functions/getCompaniesWithDistanceBatch.js
+++ b/mapbox-api/src/app/app.functions/getCompaniesWithDistanceBatch.js
@@ -22,7 +22,7 @@ exports.main = async (context = {}) => {
   let currentCompany = await extendWithGeoCoordinates(context.propertiesToSend);
   if (!currentCompany.coordinates) {
     throw new Error(
-      'Unable to calculate geo coordintes. Please specify an address for the record'
+      'Unable to calculate geo coordintes. Please specify an address for the record.'
     );
   }
 

--- a/mapbox-api/src/app/app.functions/getCompaniesWithDistanceBatch.js
+++ b/mapbox-api/src/app/app.functions/getCompaniesWithDistanceBatch.js
@@ -27,7 +27,7 @@ exports.main = async (context = {}) => {
   }
 
   const { batchSize } = context.event.payload;
-  let otherCompanies = await getCompaniesBatch({
+  let otherCompanies = await getOtherCompaniesBatch({
     hubspotClient: new hubspot.Client({
       accessToken: process.env['PRIVATE_APP_ACCESS_TOKEN'],
     }),
@@ -50,7 +50,11 @@ exports.main = async (context = {}) => {
 };
 
 // Function to fetch companies batch using HubSpot API client
-async function getCompaniesBatch({ hubspotClient, batchSize, currentCompany }) {
+async function getOtherCompaniesBatch({
+  hubspotClient,
+  batchSize,
+  currentCompany,
+}) {
   const apiResponse = await hubspotClient.crm.companies.basicApi.getPage(
     batchSize,
     undefined,

--- a/mapbox-api/src/app/extensions/SearchNeardlyCompanies.jsx
+++ b/mapbox-api/src/app/extensions/SearchNeardlyCompanies.jsx
@@ -37,10 +37,7 @@ const TopValueCompanies = ({ context, runServerless }) => {
       setTopValueCompaniesSorted(
         companies
           .filter((company) => company.distance <= radius)
-          .sort(
-            (c1, c2) =>
-              c2.properties.annualrevenue - c1.properties.annualrevenue
-          )
+          .sort((c1, c2) => c2.annualrevenue - c1.annualrevenue)
       );
     } else {
       setErrorMessage(companiesServerlessResponse.message);
@@ -62,8 +59,10 @@ const TopValueCompanies = ({ context, runServerless }) => {
   }
   return (
     <Flex direction={'column'} gap={'lg'}>
-      <Text variant="microcopy">Search for nearby companies by mile radius.</Text>
-      <Flex direction={'column'}  gap={'xs'}>
+      <Text variant="microcopy">
+        Search for nearby companies by mile radius.
+      </Text>
+      <Flex direction={'column'} gap={'xs'}>
         <Form>
           <NumberInput
             label="Radius"

--- a/mapbox-api/src/app/extensions/components/CompaniesWithDistanceTable.jsx
+++ b/mapbox-api/src/app/extensions/components/CompaniesWithDistanceTable.jsx
@@ -28,17 +28,17 @@ export const CompaniesWithDistanceTable = ({
       <TableBody>
         {companies.map((company) => {
           return (
-            <TableRow key={company.id}>
+            <TableRow key={company.hs_object_id}>
               <TableCell>
                 <Link
-                  href={`https://app.hubspot.com/contacts/${portalId}/record/0-2/${company.id}`}
+                  href={`https://app.hubspot.com/contacts/${portalId}/record/0-2/${company.hs_object_id}`}
                 >
-                  {company.properties.name}
+                  {company.name}
                 </Link>
               </TableCell>
               <TableCell>{company.distance.toFixed(2)} miles</TableCell>
               {propertiesToDisplay.map((p) => (
-                <TableCell>{company.properties[p.propertyName]}</TableCell>
+                <TableCell>{company[p.propertyName]}</TableCell>
               ))}
             </TableRow>
           );


### PR DESCRIPTION
Omit a company in calculating distance if no address specified.

When no address is specified for the current company record:
![image](https://github.com/HubSpot/ui-extensions-examples/assets/57258334/a9ea54ab-214a-4337-8945-23f20692ceb1)
