### PR TITLE
remove readonly and not existing properties

### DIFF
--- a/duplicate-contact/src/app/app.functions/duplicateContact.js
+++ b/duplicate-contact/src/app/app.functions/duplicateContact.js
@@ -163,12 +163,10 @@ const QUERY = `query data($id: String!) {
       zip
       state
       phone
-      photo
       lastname
       mobilephone
       jobtitle
       industry
-      hubspotscore
       hs_language
       firstname
       company


### PR DESCRIPTION
To avoid exceptions when duplicating contacts with readonly properties, we remove this property `hubspotscore`[(issue)](https://github.com/HubSpot/ui-extensions-examples/issues/77). Additionally, we remove the non-existent property `photo`.