### PR TITLE
feat: Add design patterns app with initial Form examples

### DIFF
--- a/design-patterns/.gitignore
+++ b/design-patterns/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+target/
+dist/
+package-lock.json
+hubspot.config.yml
+.env*
+!.env.sample
+.vite/

--- a/design-patterns/README.md
+++ b/design-patterns/README.md
@@ -1,12 +1,14 @@
 # Design Patterns ![](https://badgen.net/badge/-/TypeScript/blue?icon=typescript&label)
 
-This app includes a number of different design patterns that showcase how to compose UI components the "HubSpot" way. Each extension file contains a different pattern that you can copy and paste right into your own project.
+This app includes a number of different **Design Patterns** that showcase how to compose UI components the HubSpot way. These are our recommended best code and design practices to create a smooth, and easy to use end customer experience. Each extension file contains a different pattern that you can copy and paste right into your own project. Feel free to use these as boilerplates.
+
+[Here’s a link to the Figma Kit](https://developers.hubspot.com/docs/reference/ui-components/figma-design-kit) with Design Pattern assets if you prefer to begin with designs.
 
 ## Quick Start
 
 ### Step 1: Update your CLI and & authenticate your account
 
-1. Update to latest CLI version by running `npm install -g @hubspot/cli@latest`.
+1. Update to the latest CLI version by running `npm install -g @hubspot/cli@latest`.
 1. Run `hs init` if you haven’t already done so to create a config file for your parent account.
 1. Run `hs auth` to authenticate your account. Alternatively, select your pre-authenticated account with `hs accounts use`.
 

--- a/design-patterns/README.md
+++ b/design-patterns/README.md
@@ -1,4 +1,4 @@
-# Design Patterns
+# Design Patterns ![](https://badgen.net/badge/-/TypeScript/blue?icon=typescript&label)
 
 This app includes a number of different design patterns that showcase how to compose UI components the "HubSpot" way. Each extension file contains a different pattern that you can copy and paste right into your own project.
 

--- a/design-patterns/README.md
+++ b/design-patterns/README.md
@@ -1,0 +1,33 @@
+# Design Patterns
+
+This app includes a number of different design patterns that showcase how to compose UI components the "HubSpot" way. Each extension file contains a different pattern that you can copy and paste right into your own project.
+
+## Quick Start
+
+### Step 1: Update your CLI and & authenticate your account
+
+1. Update to latest CLI version by running `npm install -g @hubspot/cli@latest`.
+1. Run `hs init` if you haven’t already done so to create a config file for your parent account.
+1. Run `hs auth` to authenticate your account. Alternatively, select your pre-authenticated account with `hs accounts use`.
+
+### Step 2: Create the project
+
+In the folder where you want this sample to be cloned, create a new project by running `hs project create --templateSource="HubSpot/ui-extensions-examples" --location="design-patterns" --name="design-patterns" --template="design-patterns"`
+
+### Step 3: Install dependencies
+
+Now in the CLI, enter into this newly created folder by `cd design-patterns/src/app/extensions`. Run `npm install` to install the dependencies for this project.
+
+### Step 4: Upload project
+
+Run `hs project upload`. If you’d like to build directly from this project, run `hs project dev` to kickoff the dev process and see changes reflected locally as you build.
+
+### Step 5: View the cards
+
+In the main menu select `Contacts` > `Contacts` to view contact records. Click on any of the contact objects and navigate to the custom tab to access the sample card. If you don’t have any contacts in the account you’re using to view this sample, create a contact by the following steps:
+
+1. In the main menu, select `Contacts` > `Contacts`.
+2. Click `Create contact` in the top right hand corner and fill in all required fields. Click `create` once you’ve finished filling in your contact details.
+3. Your new contact should appear in the `Contacts table`. Select it and navigate to the `Custom` tab in the middle pane to access the sample card.
+
+If you haven't customized the tabs before follow step #4 from [this guide](https://developers.hubspot.com/docs/platform/ui-extensions-quickstart).

--- a/design-patterns/README.md
+++ b/design-patterns/README.md
@@ -31,3 +31,16 @@ In the main menu select `Contacts` > `Contacts` to view contact records. Click o
 3. Your new contact should appear in the `Contacts table`. Select it and navigate to the `Custom` tab in the middle pane to access the sample card.
 
 If you haven't customized the tabs before follow step #4 from [this guide](https://developers.hubspot.com/docs/platform/ui-extensions-quickstart).
+
+## Examples by Component
+
+### Form
+- [Form Action Patterns](./src/app/extensions/FormActionPatterns.tsx)
+- [Modal Form](./src/app/extensions/FormModal.tsx)
+- [Multistep Form](./src/app/extensions/FormMultistep.tsx)
+
+### Modal
+- [Modal Form](./src/app/extensions/FormModal.tsx)
+
+### Panel
+- [Multistep Form](./src/app/extensions/FormMultistep.tsx)

--- a/design-patterns/hsproject.json
+++ b/design-patterns/hsproject.json
@@ -1,0 +1,5 @@
+{
+  "name": "design-patterns",
+  "srcDir": "src",
+  "platformVersion": "2023.2"
+}

--- a/design-patterns/src/app/app.json
+++ b/design-patterns/src/app/app.json
@@ -1,0 +1,22 @@
+{
+  "name": "Design Patterns",
+  "description": "This is an app containing a variety of design patterns ready to copy and paste into your own app. The intent is to show how to effectively use components the HubSpot way.",
+  "uid": "design_patterns",
+  "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
+  "public": false,
+  "extensions": {
+    "crm": {
+      "cards": [
+        {
+          "file": "extensions/form-modal.json"
+        },
+        {
+          "file": "extensions/form-action-patterns.json"
+        },
+        {
+          "file": "extensions/form-multistep.json"
+        }
+      ]
+    }
+  }
+}

--- a/design-patterns/src/app/extensions/FormActionPatterns.tsx
+++ b/design-patterns/src/app/extensions/FormActionPatterns.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Flex,
+  Form,
+  Input,
+  Link,
+  Text,
+  TextArea,
+  hubspot,
+} from '@hubspot/ui-extensions';
+
+// Define the extension to be run within the Hubspot CRM
+hubspot.extend<'crm.record.tab'>(({ actions }) => (
+  <FormSimple actions={actions} />
+));
+
+// Define the FormSimple component.
+const FormSimple = ({ actions }) => {
+  const [formSubmitted, setFormSubmitted] = React.useState(false);
+
+  return (
+    <>
+      <Text>
+        This is some information about this form.{' '}
+        <Link href="https://www.hubspot.com">Learn more</Link>.
+      </Text>
+      <Flex>
+        <Box flex={2}>
+          {
+            // Display a success message when the form is submitted.
+            formSubmitted ? (
+              <Alert title="Success" variant="success">
+                Account created successfully.
+              </Alert>
+            ) : (
+              <Form
+                onSubmit={(e) => {
+                  // Print out the form data when the form is submitted.
+                  console.log(e.targetValue);
+                  setFormSubmitted(true);
+                }}
+              >
+                <Flex direction="column" gap="sm">
+                  <Input name="first_name" label="First Name" />
+                  <Input name="last_name" label="Last Name" />
+                  <Input
+                    name="email"
+                    label="Email"
+                    required
+                    placeholder="name@domain.com"
+                    description="We'll never share your email with anyone else."
+                    tooltip="Your email is only used for support and account purposes."
+                  />
+                  <Flex direction="column" gap="md">
+                    <TextArea
+                      name="notes"
+                      label="Notes"
+                      required
+                      placeholder="Add any notes about the account here."
+                    />
+                    <Flex align="center" gap="sm">
+                      {/* Use a Button to do the action of submitting the form. */}
+                      <Button type="submit" variant="primary">
+                        Submit
+                      </Button>
+                      {/* Use a link to navigate to another location. */}
+                      <Link href="https://www.hubspot.com">
+                        More information
+                      </Link>
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Form>
+            )
+          }
+        </Box>
+        <Box flex={1}>{''}</Box>
+      </Flex>
+    </>
+  );
+};

--- a/design-patterns/src/app/extensions/FormActionPatterns.tsx
+++ b/design-patterns/src/app/extensions/FormActionPatterns.tsx
@@ -17,15 +17,13 @@ hubspot.extend<'crm.record.tab'>(() => <FormSimple />);
 // Define the FormSimple component.
 const FormSimple = () => {
   const [formSubmitted, setFormSubmitted] = React.useState(false);
+  const [email, setEmail] = React.useState('');
 
   return (
     <>
       <Text>
         This is some information about this form.{' '}
         <Link href="https://www.hubspot.com">Learn more</Link>.
-        <Text inline={true} format={{ fontWeight: 'bold' }}>
-          Bold text test
-        </Text>
       </Text>
       {
         // Display a success message when the form is submitted.
@@ -48,6 +46,8 @@ const FormSimple = () => {
                 name="email"
                 label="Email"
                 required
+                onChange={setEmail}
+                value={email}
                 placeholder="name@domain.com"
                 description="We'll never share your email with anyone else."
                 tooltip="Your email is only used for support and account purposes."
@@ -56,12 +56,15 @@ const FormSimple = () => {
                 <TextArea
                   name="notes"
                   label="Notes"
-                  required
                   placeholder="Add any notes about the account here."
                 />
                 <Flex align="center" gap="sm">
                   {/* Use a Button to do the action of submitting the form. */}
-                  <Button type="submit" variant="primary">
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    disabled={email === ''}
+                  >
                     Submit
                   </Button>
                   {/* Use a link to navigate to another location. */}

--- a/design-patterns/src/app/extensions/FormActionPatterns.tsx
+++ b/design-patterns/src/app/extensions/FormActionPatterns.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Alert,
-  Box,
   Button,
   Flex,
   Form,
@@ -13,12 +12,10 @@ import {
 } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend<'crm.record.tab'>(({ actions }) => (
-  <FormSimple actions={actions} />
-));
+hubspot.extend<'crm.record.tab'>(() => <FormSimple />);
 
 // Define the FormSimple component.
-const FormSimple = ({ actions }) => {
+const FormSimple = () => {
   const [formSubmitted, setFormSubmitted] = React.useState(false);
 
   return (
@@ -26,6 +23,9 @@ const FormSimple = ({ actions }) => {
       <Text>
         This is some information about this form.{' '}
         <Link href="https://www.hubspot.com">Learn more</Link>.
+        <Text inline={true} format={{ fontWeight: 'bold' }}>
+          Bold text test
+        </Text>
       </Text>
       {
         // Display a success message when the form is submitted.

--- a/design-patterns/src/app/extensions/FormActionPatterns.tsx
+++ b/design-patterns/src/app/extensions/FormActionPatterns.tsx
@@ -27,58 +27,51 @@ const FormSimple = ({ actions }) => {
         This is some information about this form.{' '}
         <Link href="https://www.hubspot.com">Learn more</Link>.
       </Text>
-      <Flex>
-        <Box flex={2}>
-          {
-            // Display a success message when the form is submitted.
-            formSubmitted ? (
-              <Alert title="Success" variant="success">
-                Account created successfully.
-              </Alert>
-            ) : (
-              <Form
-                onSubmit={(e) => {
-                  // Print out the form data when the form is submitted.
-                  console.log(e.targetValue);
-                  setFormSubmitted(true);
-                }}
-              >
-                <Flex direction="column" gap="sm">
-                  <Input name="first_name" label="First Name" />
-                  <Input name="last_name" label="Last Name" />
-                  <Input
-                    name="email"
-                    label="Email"
-                    required
-                    placeholder="name@domain.com"
-                    description="We'll never share your email with anyone else."
-                    tooltip="Your email is only used for support and account purposes."
-                  />
-                  <Flex direction="column" gap="md">
-                    <TextArea
-                      name="notes"
-                      label="Notes"
-                      required
-                      placeholder="Add any notes about the account here."
-                    />
-                    <Flex align="center" gap="sm">
-                      {/* Use a Button to do the action of submitting the form. */}
-                      <Button type="submit" variant="primary">
-                        Submit
-                      </Button>
-                      {/* Use a link to navigate to another location. */}
-                      <Link href="https://www.hubspot.com">
-                        More information
-                      </Link>
-                    </Flex>
-                  </Flex>
+      {
+        // Display a success message when the form is submitted.
+        formSubmitted ? (
+          <Alert title="Success" variant="success">
+            Account created successfully.
+          </Alert>
+        ) : (
+          <Form
+            onSubmit={(e) => {
+              // Print out the form data when the form is submitted.
+              console.log(e.targetValue);
+              setFormSubmitted(true);
+            }}
+          >
+            <Flex direction="column" gap="sm">
+              <Input name="first_name" label="First Name" />
+              <Input name="last_name" label="Last Name" />
+              <Input
+                name="email"
+                label="Email"
+                required
+                placeholder="name@domain.com"
+                description="We'll never share your email with anyone else."
+                tooltip="Your email is only used for support and account purposes."
+              />
+              <Flex direction="column" gap="md">
+                <TextArea
+                  name="notes"
+                  label="Notes"
+                  required
+                  placeholder="Add any notes about the account here."
+                />
+                <Flex align="center" gap="sm">
+                  {/* Use a Button to do the action of submitting the form. */}
+                  <Button type="submit" variant="primary">
+                    Submit
+                  </Button>
+                  {/* Use a link to navigate to another location. */}
+                  <Link href="https://www.hubspot.com">More information</Link>
                 </Flex>
-              </Form>
-            )
-          }
-        </Box>
-        <Box flex={1}>{''}</Box>
-      </Flex>
+              </Flex>
+            </Flex>
+          </Form>
+        )
+      }
     </>
   );
 };

--- a/design-patterns/src/app/extensions/FormModal.tsx
+++ b/design-patterns/src/app/extensions/FormModal.tsx
@@ -21,9 +21,14 @@ hubspot.extend<'crm.record.tab'>(({ actions }) => (
 // Define the FormModal component.
 const FormModal = ({ actions }) => {
   const [formSubmitted, setFormSubmitted] = React.useState(false);
+  const [email, setEmail] = React.useState('');
 
   return (
     <>
+      <Text>
+        HubSpot recommends having forms inside overlays like Modals and Panels
+        to keep the main view clean and easy to navigate.
+      </Text>
       <Button
         overlay={
           <Modal
@@ -64,15 +69,16 @@ const FormModal = ({ actions }) => {
                       <Input
                         name="email"
                         label="Email"
+                        value={email}
                         required
                         placeholder="name@domain.com"
                         description="We'll never share your email with anyone else."
                         tooltip="Your email is only used for support and account purposes."
+                        onChange={setEmail}
                       />
                       <TextArea
                         name="notes"
                         label="Notes"
-                        required
                         placeholder="Add any notes about the account here."
                       />
                     </>
@@ -80,9 +86,15 @@ const FormModal = ({ actions }) => {
                 }
               </ModalBody>
               <ModalFooter>
-                <Button type="submit" variant="primary">
-                  Create
-                </Button>
+                {!formSubmitted && (
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    disabled={email === ''}
+                  >
+                    Submit
+                  </Button>
+                )}
                 <Button
                   onClick={() => actions.closeOverlay('modal-form-example')}
                 >

--- a/design-patterns/src/app/extensions/FormModal.tsx
+++ b/design-patterns/src/app/extensions/FormModal.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonRow,
+  Flex,
+  Form,
+  Input,
+  Link,
+  Modal,
+  ModalBody,
+  Text,
+  TextArea,
+  hubspot,
+} from '@hubspot/ui-extensions';
+
+// Define the extension to be run within the Hubspot CRM
+hubspot.extend<'crm.record.tab'>(({ actions }) => (
+  <FormModal actions={actions} />
+));
+
+// Define the FormModal component.
+const FormModal = ({ actions }) => {
+  const [formSubmitted, setFormSubmitted] = React.useState(false);
+
+  return (
+    <>
+      <Button
+        overlay={
+          <Modal
+            id="modal-form-example"
+            title="Dialog Header"
+            width="lg"
+            onClose={() => {
+              setFormSubmitted(false);
+            }}
+          >
+            <ModalBody>
+              <Text>
+                When we got all the 0's and 1's lined up, a link will show up in
+                your{' '}
+                <Link href="https://knowledge.hubspot.com/user-management/how-to-set-up-user-notifications-in-hubspot">
+                  Notification Center
+                </Link>
+                . Also, just to be sure, you're gonna get a confirmation email.
+              </Text>
+              <Flex>
+                <Box flex={2}>
+                  {
+                    // Display a success message when the form is submitted.
+                    formSubmitted ? (
+                      <Alert title="Success" variant="success">
+                        Account created successfully.
+                      </Alert>
+                    ) : (
+                      <Form
+                        onSubmit={(e) => {
+                          // Print out the form data when the form is submitted.
+                          console.log(e.targetValue);
+                          setFormSubmitted(true);
+                        }}
+                      >
+                        <Flex direction="column" gap="sm">
+                          <Input name="first_name" label="First Name" />
+                          <Input name="last_name" label="Last Name" />
+                          <Input
+                            name="email"
+                            label="Email"
+                            required
+                            placeholder="name@domain.com"
+                            description="We'll never share your email with anyone else."
+                            tooltip="Your email is only used for support and account purposes."
+                          />
+                          <Flex direction="column" gap="lg">
+                            <TextArea
+                              name="notes"
+                              label="Notes"
+                              required
+                              placeholder="Add any notes about the account here."
+                            />
+                            <ButtonRow>
+                              <Button type="submit" variant="primary">
+                                Create
+                              </Button>
+                              <Button
+                                onClick={() =>
+                                  actions.closeOverlay('modal-form-example')
+                                }
+                              >
+                                Cancel
+                              </Button>
+                            </ButtonRow>
+                          </Flex>
+                        </Flex>
+                      </Form>
+                    )
+                  }
+                </Box>
+                {/* Added an empty Box component to make the form narrower. */}
+                <Box flex={1}>{''}</Box>
+              </Flex>
+            </ModalBody>
+          </Modal>
+        }
+      >
+        Display Form
+      </Button>
+    </>
+  );
+};

--- a/design-patterns/src/app/extensions/FormModal.tsx
+++ b/design-patterns/src/app/extensions/FormModal.tsx
@@ -10,6 +10,7 @@ import {
   Link,
   Modal,
   ModalBody,
+  ModalFooter,
   Text,
   TextArea,
   hubspot,
@@ -36,32 +37,33 @@ const FormModal = ({ actions }) => {
               setFormSubmitted(false);
             }}
           >
-            <ModalBody>
-              <Text>
-                When we got all the 0's and 1's lined up, a link will show up in
-                your{' '}
-                <Link href="https://knowledge.hubspot.com/user-management/how-to-set-up-user-notifications-in-hubspot">
-                  Notification Center
-                </Link>
-                . Also, just to be sure, you're gonna get a confirmation email.
-              </Text>
-              <Flex>
-                <Box flex={2}>
-                  {
-                    // Display a success message when the form is submitted.
-                    formSubmitted ? (
-                      <Alert title="Success" variant="success">
-                        Account created successfully.
-                      </Alert>
-                    ) : (
-                      <Form
-                        onSubmit={(e) => {
-                          // Print out the form data when the form is submitted.
-                          console.log(e.targetValue);
-                          setFormSubmitted(true);
-                        }}
-                      >
-                        <Flex direction="column" gap="sm">
+            <Form
+              onSubmit={(e) => {
+                // Print out the form data when the form is submitted.
+                console.log(e.targetValue);
+                setFormSubmitted(true);
+              }}
+            >
+              <ModalBody>
+                <Text>
+                  When we got all the 0's and 1's lined up, a link will show up
+                  in your{' '}
+                  <Link href="https://knowledge.hubspot.com/user-management/how-to-set-up-user-notifications-in-hubspot">
+                    Notification Center
+                  </Link>
+                  . Also, just to be sure, you're gonna get a confirmation
+                  email.
+                </Text>
+                <Flex>
+                  <Box flex={2}>
+                    {
+                      // Display a success message when the form is submitted.
+                      formSubmitted ? (
+                        <Alert title="Success" variant="success">
+                          Account created successfully.
+                        </Alert>
+                      ) : (
+                        <>
                           <Input name="first_name" label="First Name" />
                           <Input name="last_name" label="Last Name" />
                           <Input
@@ -72,35 +74,31 @@ const FormModal = ({ actions }) => {
                             description="We'll never share your email with anyone else."
                             tooltip="Your email is only used for support and account purposes."
                           />
-                          <Flex direction="column" gap="lg">
-                            <TextArea
-                              name="notes"
-                              label="Notes"
-                              required
-                              placeholder="Add any notes about the account here."
-                            />
-                            <ButtonRow>
-                              <Button type="submit" variant="primary">
-                                Create
-                              </Button>
-                              <Button
-                                onClick={() =>
-                                  actions.closeOverlay('modal-form-example')
-                                }
-                              >
-                                Cancel
-                              </Button>
-                            </ButtonRow>
-                          </Flex>
-                        </Flex>
-                      </Form>
-                    )
-                  }
-                </Box>
-                {/* Added an empty Box component to make the form narrower. */}
-                <Box flex={1}>{''}</Box>
-              </Flex>
-            </ModalBody>
+                          <TextArea
+                            name="notes"
+                            label="Notes"
+                            required
+                            placeholder="Add any notes about the account here."
+                          />
+                        </>
+                      )
+                    }
+                  </Box>
+                  {/* Added an empty Box component to make the form narrower. */}
+                  <Box flex={1}>{''}</Box>
+                </Flex>
+              </ModalBody>
+              <ModalFooter>
+                <Button type="submit" variant="primary">
+                  Create
+                </Button>
+                <Button
+                  onClick={() => actions.closeOverlay('modal-form-example')}
+                >
+                  Cancel
+                </Button>
+              </ModalFooter>
+            </Form>
           </Modal>
         }
       >

--- a/design-patterns/src/app/extensions/FormModal.tsx
+++ b/design-patterns/src/app/extensions/FormModal.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {
   Alert,
-  Box,
   Button,
-  ButtonRow,
-  Flex,
   Form,
   Input,
   Link,

--- a/design-patterns/src/app/extensions/FormModal.tsx
+++ b/design-patterns/src/app/extensions/FormModal.tsx
@@ -54,39 +54,33 @@ const FormModal = ({ actions }) => {
                   . Also, just to be sure, you're gonna get a confirmation
                   email.
                 </Text>
-                <Flex>
-                  <Box flex={2}>
-                    {
-                      // Display a success message when the form is submitted.
-                      formSubmitted ? (
-                        <Alert title="Success" variant="success">
-                          Account created successfully.
-                        </Alert>
-                      ) : (
-                        <>
-                          <Input name="first_name" label="First Name" />
-                          <Input name="last_name" label="Last Name" />
-                          <Input
-                            name="email"
-                            label="Email"
-                            required
-                            placeholder="name@domain.com"
-                            description="We'll never share your email with anyone else."
-                            tooltip="Your email is only used for support and account purposes."
-                          />
-                          <TextArea
-                            name="notes"
-                            label="Notes"
-                            required
-                            placeholder="Add any notes about the account here."
-                          />
-                        </>
-                      )
-                    }
-                  </Box>
-                  {/* Added an empty Box component to make the form narrower. */}
-                  <Box flex={1}>{''}</Box>
-                </Flex>
+                {
+                  // Display a success message when the form is submitted.
+                  formSubmitted ? (
+                    <Alert title="Success" variant="success">
+                      Account created successfully.
+                    </Alert>
+                  ) : (
+                    <>
+                      <Input name="first_name" label="First Name" />
+                      <Input name="last_name" label="Last Name" />
+                      <Input
+                        name="email"
+                        label="Email"
+                        required
+                        placeholder="name@domain.com"
+                        description="We'll never share your email with anyone else."
+                        tooltip="Your email is only used for support and account purposes."
+                      />
+                      <TextArea
+                        name="notes"
+                        label="Notes"
+                        required
+                        placeholder="Add any notes about the account here."
+                      />
+                    </>
+                  )
+                }
               </ModalBody>
               <ModalFooter>
                 <Button type="submit" variant="primary">

--- a/design-patterns/src/app/extensions/FormMultistep.tsx
+++ b/design-patterns/src/app/extensions/FormMultistep.tsx
@@ -28,9 +28,33 @@ hubspot.extend<'crm.record.tab'>(({ actions }) => (
 const FormMultistep = ({ actions }) => {
   const [formSubmitted, setFormSubmitted] = React.useState(false);
   const [formStep, setFormStep] = React.useState(0);
+  const [email, setEmail] = React.useState('');
+  const today = new Date();
+  const [eventDate, setEventDate] = React.useState({
+    year: today.getFullYear(),
+    month: today.getMonth(),
+    date: today.getDate(),
+  });
+  const [eventName, setEventName] = React.useState('');
+
+  const activateNextButton = () => {
+    if (
+      (formStep === 0 && email !== '') ||
+      (formStep === 1 && eventDate !== null && eventName !== '') ||
+      formStep === 2
+    ) {
+      return true;
+    }
+
+    return false;
+  };
 
   return (
     <>
+      <Text>
+        HubSpot recommends having forms inside overlays like Modals and Panels
+        to keep the main view clean and easy to navigate.
+      </Text>
       <Button
         overlay={
           <Panel
@@ -46,7 +70,6 @@ const FormMultistep = ({ actions }) => {
             <Form
               onSubmit={(e) => {
                 // Print out the form data when the form is submitted.
-                console.log(e.targetValue);
                 setFormStep(4);
                 setFormSubmitted(true);
               }}
@@ -84,6 +107,7 @@ const FormMultistep = ({ actions }) => {
                                 name="email"
                                 label="Email"
                                 required
+                                onChange={setEmail}
                                 placeholder="name@domain.com"
                                 description="We'll never share your email with anyone else."
                                 tooltip="Your email is only used for support and account purposes."
@@ -95,11 +119,18 @@ const FormMultistep = ({ actions }) => {
                               <DateInput
                                 name="event_date"
                                 label="Event Date"
+                                value={eventDate}
+                                onChange={(value) => {
+                                  console.log(value);
+                                  setEventDate(value);
+                                }}
                                 required
                               />
                               <Input
                                 name="event_name"
                                 label="Event Name"
+                                value={eventName}
+                                onChange={setEventName}
                                 required
                               />
                             </>
@@ -120,7 +151,6 @@ const FormMultistep = ({ actions }) => {
                               <TextArea
                                 name="notes"
                                 label="Notes"
-                                required
                                 placeholder="Additional notes about your rating."
                               />
                             </>
@@ -158,6 +188,7 @@ const FormMultistep = ({ actions }) => {
                       variant="primary"
                       type="button"
                       onClick={() => setFormStep(formStep + 1)}
+                      disabled={!activateNextButton()}
                     >
                       Next
                     </Button>

--- a/design-patterns/src/app/extensions/FormMultistep.tsx
+++ b/design-patterns/src/app/extensions/FormMultistep.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Alert,
-  Box,
   Button,
   DateInput,
   Flex,
@@ -148,7 +147,6 @@ const FormMultistep = ({ actions }) => {
                         </>
                       )
                     }
-                    {/* Added an empty Box component to make the form narrower. */}
                   </Flex>
                 </PanelSection>
               </PanelBody>

--- a/design-patterns/src/app/extensions/FormMultistep.tsx
+++ b/design-patterns/src/app/extensions/FormMultistep.tsx
@@ -69,91 +69,86 @@ const FormMultistep = ({ actions }) => {
                       . Also, just to be sure, you're gonna get a confirmation
                       email.
                     </Text>
-                    <Flex>
-                      <Box flex={2}>
-                        {
-                          // Display a success message when the form is submitted.
-                          formSubmitted ? (
-                            <Alert title="Success" variant="success">
-                              Form submitted successfully.
-                            </Alert>
-                          ) : (
+                    {
+                      // Display a success message when the form is submitted.
+                      formSubmitted ? (
+                        <Alert title="Success" variant="success">
+                          Form submitted successfully.
+                        </Alert>
+                      ) : (
+                        <>
+                          {formStep === 0 && (
                             <>
-                              {formStep === 0 && (
-                                <>
-                                  <Input name="first_name" label="First Name" />
-                                  <Input name="last_name" label="Last Name" />
-                                  <Input
-                                    name="email"
-                                    label="Email"
-                                    required
-                                    placeholder="name@domain.com"
-                                    description="We'll never share your email with anyone else."
-                                    tooltip="Your email is only used for support and account purposes."
-                                  />
-                                </>
-                              )}
-                              {formStep === 1 && (
-                                <>
-                                  <DateInput
-                                    name="event_date"
-                                    label="Event Date"
-                                    required
-                                  />
-                                  <Input
-                                    name="event_name"
-                                    label="Event Name"
-                                    required
-                                  />
-                                </>
-                              )}
-                              {formStep === 2 && (
-                                <>
-                                  <Select
-                                    label="Rating"
-                                    options={[
-                                      { label: '☆☆☆☆☆', value: 5 },
-                                      { label: '☆☆☆☆', value: 4 },
-                                      { label: '☆☆☆', value: 3 },
-                                      { label: '☆☆', value: 2 },
-                                      { label: '☆', value: 1 },
-                                    ]}
-                                    name="rating"
-                                  />
-                                  <TextArea
-                                    name="notes"
-                                    label="Notes"
-                                    required
-                                    placeholder="Additional notes about your rating."
-                                  />
-                                </>
-                              )}
-                              {formStep === 3 && (
-                                <>
-                                  <Select
-                                    label="Update Frequency"
-                                    options={[
-                                      { label: 'Daily', value: 'daily' },
-                                      { label: 'Weekly', value: 'weekly' },
-                                      { label: 'Monthly', value: 'monthly' },
-                                    ]}
-                                    name="update_frequency"
-                                  />
-                                  <NumberInput
-                                    name="number_of_records"
-                                    label="Number of Records"
-                                    min={1}
-                                    max={100}
-                                  />
-                                </>
-                              )}
+                              <Input name="first_name" label="First Name" />
+                              <Input name="last_name" label="Last Name" />
+                              <Input
+                                name="email"
+                                label="Email"
+                                required
+                                placeholder="name@domain.com"
+                                description="We'll never share your email with anyone else."
+                                tooltip="Your email is only used for support and account purposes."
+                              />
                             </>
-                          )
-                        }
-                      </Box>
-                      {/* Added an empty Box component to make the form narrower. */}
-                      <Box flex={1}>{''}</Box>
-                    </Flex>
+                          )}
+                          {formStep === 1 && (
+                            <>
+                              <DateInput
+                                name="event_date"
+                                label="Event Date"
+                                required
+                              />
+                              <Input
+                                name="event_name"
+                                label="Event Name"
+                                required
+                              />
+                            </>
+                          )}
+                          {formStep === 2 && (
+                            <>
+                              <Select
+                                label="Rating"
+                                options={[
+                                  { label: '☆☆☆☆☆', value: 5 },
+                                  { label: '☆☆☆☆', value: 4 },
+                                  { label: '☆☆☆', value: 3 },
+                                  { label: '☆☆', value: 2 },
+                                  { label: '☆', value: 1 },
+                                ]}
+                                name="rating"
+                              />
+                              <TextArea
+                                name="notes"
+                                label="Notes"
+                                required
+                                placeholder="Additional notes about your rating."
+                              />
+                            </>
+                          )}
+                          {formStep === 3 && (
+                            <>
+                              <Select
+                                label="Update Frequency"
+                                options={[
+                                  { label: 'Daily', value: 'daily' },
+                                  { label: 'Weekly', value: 'weekly' },
+                                  { label: 'Monthly', value: 'monthly' },
+                                ]}
+                                name="update_frequency"
+                              />
+                              <NumberInput
+                                name="number_of_records"
+                                label="Number of Records"
+                                min={1}
+                                max={100}
+                              />
+                            </>
+                          )}
+                        </>
+                      )
+                    }
+                    {/* Added an empty Box component to make the form narrower. */}
                   </Flex>
                 </PanelSection>
               </PanelBody>

--- a/design-patterns/src/app/extensions/FormMultistep.tsx
+++ b/design-patterns/src/app/extensions/FormMultistep.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  DateInput,
+  Flex,
+  Form,
+  Input,
+  Link,
+  NumberInput,
+  Panel,
+  PanelBody,
+  PanelFooter,
+  PanelSection,
+  Select,
+  StepIndicator,
+  Text,
+  TextArea,
+  hubspot,
+} from '@hubspot/ui-extensions';
+
+// Define the extension to be run within the Hubspot CRM
+hubspot.extend<'crm.record.tab'>(({ actions }) => (
+  <FormMultistep actions={actions} />
+));
+
+// Define the FormSimple component.
+const FormMultistep = ({ actions }) => {
+  const [formSubmitted, setFormSubmitted] = React.useState(false);
+  const [formStep, setFormStep] = React.useState(0);
+
+  return (
+    <>
+      <Button
+        overlay={
+          <Panel
+            id="simple-form-example"
+            title="Dialog Header"
+            width="md"
+            variant="modal"
+            onClose={() => {
+              setFormStep(0);
+              setFormSubmitted(false);
+            }}
+          >
+            <Form
+              onSubmit={(e) => {
+                // Print out the form data when the form is submitted.
+                console.log(e.targetValue);
+                setFormStep(4);
+                setFormSubmitted(true);
+              }}
+            >
+              <PanelBody>
+                <PanelSection>
+                  {/* Wrap the StepIndicator in Flex to ensure it goes full-width */}
+                  <Flex gap="md" direction="column">
+                    <StepIndicator
+                      currentStep={formStep}
+                      stepNames={['Info', 'Event', 'Rate', 'Followup']}
+                    />
+                    <Text>
+                      When we got all the 0's and 1's lined up, a link will show
+                      up in your{' '}
+                      <Link href="https://knowledge.hubspot.com/user-management/how-to-set-up-user-notifications-in-hubspot">
+                        Notification Center
+                      </Link>
+                      . Also, just to be sure, you're gonna get a confirmation
+                      email.
+                    </Text>
+                    <Flex>
+                      <Box flex={2}>
+                        {
+                          // Display a success message when the form is submitted.
+                          formSubmitted ? (
+                            <Alert title="Success" variant="success">
+                              Form submitted successfully.
+                            </Alert>
+                          ) : (
+                            <>
+                              {formStep === 0 && (
+                                <>
+                                  <Input name="first_name" label="First Name" />
+                                  <Input name="last_name" label="Last Name" />
+                                  <Input
+                                    name="email"
+                                    label="Email"
+                                    required
+                                    placeholder="name@domain.com"
+                                    description="We'll never share your email with anyone else."
+                                    tooltip="Your email is only used for support and account purposes."
+                                  />
+                                </>
+                              )}
+                              {formStep === 1 && (
+                                <>
+                                  <DateInput
+                                    name="event_date"
+                                    label="Event Date"
+                                    required
+                                  />
+                                  <Input
+                                    name="event_name"
+                                    label="Event Name"
+                                    required
+                                  />
+                                </>
+                              )}
+                              {formStep === 2 && (
+                                <>
+                                  <Select
+                                    label="Rating"
+                                    options={[
+                                      { label: '☆☆☆☆☆', value: 5 },
+                                      { label: '☆☆☆☆', value: 4 },
+                                      { label: '☆☆☆', value: 3 },
+                                      { label: '☆☆', value: 2 },
+                                      { label: '☆', value: 1 },
+                                    ]}
+                                    name="rating"
+                                  />
+                                  <TextArea
+                                    name="notes"
+                                    label="Notes"
+                                    required
+                                    placeholder="Additional notes about your rating."
+                                  />
+                                </>
+                              )}
+                              {formStep === 3 && (
+                                <>
+                                  <Select
+                                    label="Update Frequency"
+                                    options={[
+                                      { label: 'Daily', value: 'daily' },
+                                      { label: 'Weekly', value: 'weekly' },
+                                      { label: 'Monthly', value: 'monthly' },
+                                    ]}
+                                    name="update_frequency"
+                                  />
+                                  <NumberInput
+                                    name="number_of_records"
+                                    label="Number of Records"
+                                    min={1}
+                                    max={100}
+                                  />
+                                </>
+                              )}
+                            </>
+                          )
+                        }
+                      </Box>
+                      {/* Added an empty Box component to make the form narrower. */}
+                      <Box flex={1}>{''}</Box>
+                    </Flex>
+                  </Flex>
+                </PanelSection>
+              </PanelBody>
+              <PanelFooter>
+                {
+                  // Display the "Next" button for all steps except the last step.
+                  formStep < 3 && (
+                    <Button
+                      variant="primary"
+                      type="button"
+                      onClick={() => setFormStep(formStep + 1)}
+                    >
+                      Next
+                    </Button>
+                  )
+                }
+                {
+                  // Display the "Submit" button on the last step.
+                  formStep === 3 && (
+                    <Button type="submit" variant="primary">
+                      Submit
+                    </Button>
+                  )
+                }
+                {/* Use this button to close the Panel */}
+                <Button
+                  onClick={() => actions.closeOverlay('simple-form-example')}
+                >
+                  {formSubmitted === true ? 'Close' : 'Cancel'}
+                </Button>
+              </PanelFooter>
+            </Form>
+          </Panel>
+        }
+      >
+        Display Form
+      </Button>
+    </>
+  );
+};

--- a/design-patterns/src/app/extensions/form-action-patterns.json
+++ b/design-patterns/src/app/extensions/form-action-patterns.json
@@ -1,0 +1,12 @@
+{
+  "type": "crm-card",
+  "data": {
+    "title": "Form Action Patterns",
+    "uid": "form_action_patterns_card",
+    "location": "crm.record.tab",
+    "module": {
+      "file": "FormActionPatterns.tsx"
+    },
+    "objectTypes": [{ "name": "contacts" }]
+  }
+}

--- a/design-patterns/src/app/extensions/form-modal.json
+++ b/design-patterns/src/app/extensions/form-modal.json
@@ -1,0 +1,12 @@
+{
+  "type": "crm-card",
+  "data": {
+    "title": "Modal Form",
+    "uid": "form_modal_card",
+    "location": "crm.record.tab",
+    "module": {
+      "file": "FormModal.tsx"
+    },
+    "objectTypes": [{ "name": "contacts" }]
+  }
+}

--- a/design-patterns/src/app/extensions/form-multistep.json
+++ b/design-patterns/src/app/extensions/form-multistep.json
@@ -1,0 +1,12 @@
+{
+  "type": "crm-card",
+  "data": {
+    "title": "Multistep Form",
+    "uid": "form_multistep_card",
+    "location": "crm.record.tab",
+    "module": {
+      "file": "FormMultistep.tsx"
+    },
+    "objectTypes": [{ "name": "contacts" }]
+  }
+}

--- a/design-patterns/src/app/extensions/package.json
+++ b/design-patterns/src/app/extensions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hubspot-design-patterns",
+  "version": "0.1.0",
+  "author": "HubSpot",
+  "license": "MIT",
+  "dependencies": {
+    "@hubspot/ui-extensions": "latest",
+    "react": "^18.2.0"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new app to showcase design patterns, aka composed sets of components ready to copy and paste into projects. This initial phase of work includes three `Form` component patterns.

### Form Components

**Modal Form**
<img width="606" alt="modal-form" src="https://github.com/user-attachments/assets/dc21ef3c-966c-4d25-8e81-a59851a3dfc8" />


**Form Action Patterns**
<img width="543" alt="form-actions-card" src="https://github.com/user-attachments/assets/a8f9a323-1efb-4539-b9c1-28ea77329696" />

**Multistep Form**
<img width="734" alt="panel-form" src="https://github.com/user-attachments/assets/7bbba551-f71e-44f2-9d61-ee49cc3be157" />
