### PR TITLE
feat: Update examples to use `hubspot.serverless` for calling app functions

### DIFF
--- a/bi-directional-property-refresh/src/app/extensions/PropertyRefreshExtension.tsx
+++ b/bi-directional-property-refresh/src/app/extensions/PropertyRefreshExtension.tsx
@@ -11,13 +11,11 @@ import {
   Text,
 } from '@hubspot/ui-extensions';
 
-import { CrmStageTracker, CrmPropertyList } from '@hubspot/ui-extensions/crm';
-
-hubspot.extend<'crm.record.tab'>(({ actions, runServerlessFunction }) => (
-  <Extension actions={actions} runServerlessFunction={runServerlessFunction} />
+hubspot.extend<'crm.record.tab'>(({ actions }) => (
+  <Extension actions={actions} />
 ));
 
-const Extension = ({ actions, runServerlessFunction }) => {
+const Extension = ({ actions }) => {
   const {
     fetchCrmObjectProperties,
     onCrmPropertiesUpdate,
@@ -39,24 +37,30 @@ const Extension = ({ actions, runServerlessFunction }) => {
   });
 
   useEffect(() => {
-    runServerlessFunction({ name: 'getLifecycleStage' }).then(
-      (serverlessResponse) => {
-        if (serverlessResponse.status == 'SUCCESS') {
-          setLifecycleStage(serverlessResponse.response);
-        }
-      }
-    );
+    hubspot
+      .serverless('getLifecycleStage')
+      .then((response) => {
+        setLifecycleStage(response);
+      })
+      .catch((err) => {
+        console.error(err.message);
+        setLifecycleStage(null);
+      });
   }, []);
 
   const onChange = (stage) => {
     console.log(stage);
-    runServerlessFunction({
-      name: 'updateLifecycleStage',
-      parameters: { stage },
-      propertiesToSend: ['hs_object_id'],
-    }).then(() => {
-      refreshObjectProperties();
-    });
+    hubspot
+      .serverless('updateLifecycleStage', {
+        parameters: { stage },
+        propertiesToSend: ['hs_object_id'],
+      })
+      .then(() => {
+        refreshObjectProperties();
+      })
+      .catch((err) => {
+        console.error(err.message);
+      });
   };
 
   return (

--- a/crm-data-components/src/app/extensions/StageTrackerExtension.tsx
+++ b/crm-data-components/src/app/extensions/StageTrackerExtension.tsx
@@ -15,21 +15,15 @@ import {
   CrmAssociationPivot,
 } from '@hubspot/ui-extensions/crm';
 
-hubspot.extend(({ context, actions, runServerlessFunction }) => (
+hubspot.extend<'crm.record.tab'>(({ context, actions }) => (
   <Extension
     context={context}
-    runServerless={runServerlessFunction}
     fetchCrmObjectProperties={actions.fetchCrmObjectProperties}
     addAlert={actions.addAlert}
   />
 ));
 
-const Extension = ({
-  context,
-  runServerless,
-  fetchCrmObjectProperties,
-  addAlert,
-}) => {
+const Extension = ({ context, fetchCrmObjectProperties, addAlert }) => {
   const [stage, setStage] = useState<string | null>(null);
   const [showProperties, setShowProperties] = useState(true);
   const [dealId, setDealId] = useState<string | null>(null);
@@ -75,31 +69,31 @@ const Extension = ({
         setStage(properties.dealstage);
         setDealId(properties.hs_object_id);
         setDealname(properties.dealname);
-      }
+      },
     );
   }, [stage]);
 
   const handleStageChange = useCallback(
     (newStage: string) => {
-      runServerless({
-        name: 'updateDeal',
-        parameters: {
-          dealId: dealId!,
-          dealStage: newStage,
-        },
-      }).then((resp: { status: string; message?: string }) => {
-        if (resp.status === 'SUCCESS') {
+      hubspot
+        .serverless('updateDeal', {
+          parameters: {
+            dealId: dealId!,
+            dealStage: newStage,
+          },
+        })
+        .then(() => {
           addAlert({
             type: 'success',
             message: 'Deal stage updated successfully',
           });
           setStage(newStage);
-        } else {
-          setError(resp.message || 'An error occurred');
-        }
-      });
+        })
+        .catch((error) => {
+          setError(error?.message || 'An error occurred');
+        });
     },
-    [dealId, addAlert, runServerless]
+    [dealId, addAlert],
   );
 
   const handlePropertyToggle = useCallback(() => {
@@ -113,7 +107,8 @@ const Extension = ({
   return (
     <Flex direction={'column'} gap={'lg'}>
       <Text variant="microcopy">
-        This is example is a card for deal records to view and update pipeline stage progress.
+        This is example is a card for deal records to view and update pipeline
+        stage progress.
       </Text>
       <Flex direction={'column'} justify={'start'} gap={'medium'}>
         <Heading>Deal status : {dealname}</Heading>

--- a/deals-summary/src/app/extensions/DealsSummaryExampleCard.jsx
+++ b/deals-summary/src/app/extensions/DealsSummaryExampleCard.jsx
@@ -10,12 +10,10 @@ import {
 import { hubspot } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ runServerlessFunction }) => (
-  <DealsSummary runServerless={runServerlessFunction} />
-));
+hubspot.extend(() => <DealsSummary />);
 
-// Define the Extension component, taking in runServerless prop
-const DealsSummary = ({ runServerless }) => {
+// Define the Extension component
+const DealsSummary = () => {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
   const [dealsCount, setDealsCount] = useState(0);
@@ -23,18 +21,13 @@ const DealsSummary = ({ runServerless }) => {
 
   useEffect(() => {
     // Request statistics data from serverless function
-    runServerless({
-      name: 'get-data',
-      propertiesToSend: ['hs_object_id'],
-    })
-      .then((serverlessResponse) => {
-        if (serverlessResponse.status == 'SUCCESS') {
-          const { response } = serverlessResponse;
-          setDealsCount(response.dealsCount);
-          setTotalAmount(response.totalAmount);
-        } else {
-          setErrorMessage(serverlessResponse.message);
-        }
+    hubspot
+      .serverless('get-data', {
+        propertiesToSend: ['hs_object_id'],
+      })
+      .then((response) => {
+        setDealsCount(response.dealsCount);
+        setTotalAmount(response.totalAmount);
       })
       .catch((error) => {
         setErrorMessage(error.message);
@@ -42,7 +35,7 @@ const DealsSummary = ({ runServerless }) => {
       .finally(() => {
         setLoading(false);
       });
-  }, [runServerless]);
+  }, []);
 
   if (loading) {
     // If loading, show a spinner
@@ -58,7 +51,10 @@ const DealsSummary = ({ runServerless }) => {
   }
   return (
     <Flex direction={'column'} gap={'lg'}>
-      <Text variant="microcopy">This example shows you how you can view a high-level summary of data from associated deals.</Text>
+      <Text variant="microcopy">
+        This example shows you how you can view a high-level summary of data
+        from associated deals.
+      </Text>
       <Statistics>
         <StatisticsItem label="Open deals" number={dealsCount}>
           <Text>Total number of deals contact is associated with</Text>

--- a/duplicate-contact/src/app/extensions/Extension.tsx
+++ b/duplicate-contact/src/app/extensions/Extension.tsx
@@ -11,20 +11,18 @@ import {
   Text,
   Flex,
   hubspot,
-  type Context,
-  type ServerlessFuncRunner,
+  type CrmContext,
 } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend<'crm.record.tab'>(({ context, runServerlessFunction }) => (
+hubspot.extend<'crm.record.tab'>(({ context }) => (
   // This line specifies what is returned to the CRM tab
-  <Extension runServerless={runServerlessFunction} context={context} />
+  <Extension context={context} />
 ));
 
 // Define the types for the properties we're going to use in our Extension component
 interface ExtensionProps {
-  runServerless: ServerlessFuncRunner;
-  context: Context;
+  context: CrmContext;
 }
 
 // Define the interface for the Association type
@@ -39,8 +37,8 @@ export interface AssociationsGQL {
   company_collection__primary: Association;
 }
 
-// Define the Extension component, taking in runServerless and context as props
-const Extension = ({ runServerless, context }: ExtensionProps) => {
+// Define the Extension component, taking in context as props
+const Extension = ({ context }: ExtensionProps) => {
   const [loading, setLoading] = useState(true);
   const [associations, setAssociations] = useState<AssociationsGQL>();
   const [email, setEmail] = useState('');
@@ -49,39 +47,42 @@ const Extension = ({ runServerless, context }: ExtensionProps) => {
 
   useEffect(() => {
     // Request association data from serverless function
-    runServerless({
-      name: 'fetchAssociations',
-      propertiesToSend: ['hs_object_id'],
-    }).then((resp) => {
-      setLoading(false); // End loading state
-      if (resp.status === 'SUCCESS') {
+    hubspot
+      .serverless('fetchAssociations', {
+        propertiesToSend: ['hs_object_id'],
+      })
+      .then((response) => {
         // Set associations with response data
-        setAssociations(resp.response.associations as AssociationsGQL);
-      } else {
-        setError(resp.message); // Set error message from response
-      }
-    });
-  }, [runServerless]);
+        setAssociations(response.associations as AssociationsGQL);
+      })
+      .catch((error) => {
+        setError(error.message);
+      })
+      .finally(() => {
+        setLoading(false); // End loading state
+      });
+  }, []);
 
   // Function to handle contact duplication
   const duplicateContact = () => {
     setLoading(true);
-    runServerless({
-      name: 'duplicateContact',
-      propertiesToSend: ['hs_object_id'],
-      parameters: { associations, email }, // Send current associations and email as parameters
-    }).then((resp) => {
-      setLoading(false);
-      if (resp.status === 'SUCCESS') {
-        const contact = resp.response;
+    hubspot
+      .serverless('duplicateContact', {
+        propertiesToSend: ['hs_object_id'],
+        parameters: { associations, email }, // Send current associations and email as parameters
+      })
+      .then((contact) => {
         // Set the URL to the newly created contact
         setUrl(
           `https://app.hubspot.com/contacts/${context.portal.id}/contact/${contact.id}`
         );
-      } else {
-        setError(resp.message); // Set error message from response
-      }
-    });
+      })
+      .catch((error) => {
+        setError(error.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   };
 
   if (loading) {
@@ -100,7 +101,8 @@ const Extension = ({ runServerless, context }: ExtensionProps) => {
       <>
         <Flex direction={'column'} gap={'lg'}>
           <Text variant="microcopy">
-            Duplicate a contact along with some of its properties and associated deals and companies.
+            Duplicate a contact along with some of its properties and associated
+            deals and companies.
           </Text>
           <Flex direction={'column'} gap={'sm'}>
             <Text format={{ fontWeight: 'bold' }}>

--- a/generate-quotes/src/app/extensions/GenerateMultipleQuotesExampleCard.jsx
+++ b/generate-quotes/src/app/extensions/GenerateMultipleQuotesExampleCard.jsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import { hubspot } from '@hubspot/ui-extensions';
-import { LoadingSpinner, Flex, Text, StepIndicator } from '@hubspot/ui-extensions';
+import {
+  LoadingSpinner,
+  Flex,
+  Text,
+  StepIndicator,
+} from '@hubspot/ui-extensions';
 import { TripDetails } from './components/TripDetails.jsx';
 import { BusOptions } from './components/BusOptions.jsx';
 import { QuotesView } from './components/QuotesView.jsx';
@@ -14,11 +19,9 @@ const Steps = {
 };
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ runServerlessFunction }) => (
-  <ShuttleBusQuotes runServerless={runServerlessFunction} />
-));
+hubspot.extend(() => <ShuttleBusQuotes />);
 
-const ShuttleBusQuotes = ({ runServerless }) => {
+const ShuttleBusQuotes = () => {
   const [step, setStep] = useState(Steps.QuotesView);
   const [passengers, setPassengers] = useState();
   const [distance, setDistance] = useState();
@@ -28,8 +31,7 @@ const ShuttleBusQuotes = ({ runServerless }) => {
 
   const generateQuote = ({ ...payload }) => {
     // Execute serverless function to generate a quote
-    return runServerless({
-      name: 'createQuote',
+    return hubspot.serverless('createQuote', {
       propertiesToSend: ['hs_object_id'],
       payload,
     });
@@ -63,8 +65,9 @@ const ShuttleBusQuotes = ({ runServerless }) => {
       {loading == false && (
         <Flex direction="column" gap="lg">
           <Text variant="microcopy">
-            This example uses a fictional shuttle bus rental company with several service options.
-            The card matches customers with the most appropriate service, and then generates multiple quotes for them.
+            This example uses a fictional shuttle bus rental company with
+            several service options. The card matches customers with the most
+            appropriate service, and then generates multiple quotes for them.
           </Text>
           <Flex direction="column" gap="xs">
             {/* Render a step indicator  */}

--- a/mapbox-api/src/app/extensions/CompaniesNearTheCurrentRecord.jsx
+++ b/mapbox-api/src/app/extensions/CompaniesNearTheCurrentRecord.jsx
@@ -4,15 +4,14 @@ import { CompaniesWithDistanceTable } from './components/CompaniesWithDistanceTa
 import { hubspot } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ actions, context, runServerlessFunction }) => (
+hubspot.extend(({ actions, context }) => (
   <NearestCompanies
-    runServerless={runServerlessFunction}
     context={context}
     fetchProperties={actions.fetchCrmObjectProperties}
   />
 ));
 
-const NearestCompanies = ({ context, runServerless, fetchProperties }) => {
+const NearestCompanies = ({ context, fetchProperties }) => {
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
   const [nearestCompaniesSorted, setNearestCompaniesSorted] = useState([]);
@@ -22,24 +21,25 @@ const NearestCompanies = ({ context, runServerless, fetchProperties }) => {
     async function fetchCompaniesWithDistanceBatch() {
       setLoading(true);
       // Request companies batch from serverless function
-      const companiesServerlessResponse = await runServerless({
-        name: 'getCompaniesWithDistanceBatch',
-        propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
-        payload: { batchSize: 30 },
-      });
-      if (companiesServerlessResponse.status == 'SUCCESS') {
-        const { companies } = companiesServerlessResponse.response;
+      try {
+        const { companies } = await hubspot.serverless(
+          'getCompaniesWithDistanceBatch',
+          {
+            propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
+            payload: { batchSize: 30 },
+          }
+        );
         // Sort companies by distance
         setNearestCompaniesSorted(
           companies.sort((c1, c2) => c1.distance - c2.distance)
         );
-      } else {
-        setErrorMessage(companiesServerlessResponse.message);
+      } catch (error) {
+        setErrorMessage(error.message);
       }
       setLoading(false);
     }
     fetchCompaniesWithDistanceBatch();
-  }, [fetchProperties, runServerless]);
+  }, [fetchProperties]);
 
   if (errorMessage) {
     // If there's an error, show an alert
@@ -55,7 +55,10 @@ const NearestCompanies = ({ context, runServerless, fetchProperties }) => {
   }
   return (
     <Flex direction={'column'} gap={'lg'}>
-      <Text variant="microcopy"> View the companies nearest to the currently displaying record.</Text>
+      <Text variant="microcopy">
+        {' '}
+        View the companies nearest to the currently displaying record.
+      </Text>
       <CompaniesWithDistanceTable
         portalId={context.portal.id}
         companies={nearestCompaniesSorted.slice(0, companiesToDisplay)}

--- a/mapbox-api/src/app/extensions/SearchNeardlyCompanies.jsx
+++ b/mapbox-api/src/app/extensions/SearchNeardlyCompanies.jsx
@@ -13,11 +13,9 @@ import { CompaniesWithDistanceTable } from './components/CompaniesWithDistanceTa
 import { hubspot } from '@hubspot/ui-extensions';
 
 // Define the extension to be run within the Hubspot CRM
-hubspot.extend(({ context, runServerlessFunction }) => (
-  <TopValueCompanies context={context} runServerless={runServerlessFunction} />
-));
+hubspot.extend(({ context }) => <TopValueCompanies context={context} />);
 
-const TopValueCompanies = ({ context, runServerless }) => {
+const TopValueCompanies = ({ context }) => {
   const [topValueCompaniesSorted, setTopValueCompaniesSorted] = useState([]);
   const [radius, setRadius] = useState(50);
   const [loading, setLoading] = useState(false);
@@ -27,20 +25,21 @@ const TopValueCompanies = ({ context, runServerless }) => {
 
   const executeServerless = async () => {
     setLoading(true);
-    const companiesServerlessResponse = await runServerless({
-      name: 'getCompaniesWithDistanceBatch',
-      propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
-      payload: { batchSize: companiesBatchSize },
-    });
-    if (companiesServerlessResponse.status == 'SUCCESS') {
-      const { companies } = companiesServerlessResponse.response;
+    try {
+      const { companies } = await hubspot.serverless(
+        'getCompaniesWithDistanceBatch',
+        {
+          propertiesToSend: ['hs_object_id', 'city', 'state', 'address'],
+          payload: { batchSize: companiesBatchSize },
+        }
+      );
       setTopValueCompaniesSorted(
         companies
           .filter((company) => company.distance <= radius)
           .sort((c1, c2) => c2.annualrevenue - c1.annualrevenue)
       );
-    } else {
-      setErrorMessage(companiesServerlessResponse.message);
+    } catch (error) {
+      setErrorMessage(error.message);
     }
     setLoading(false);
   };

--- a/multi-step-flow/src/app/extensions/OrderMealExtension.tsx
+++ b/multi-step-flow/src/app/extensions/OrderMealExtension.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { hubspot } from '@hubspot/ui-extensions';
 import { OrderMealCard } from './components/OrderMealCard';
 
-hubspot.extend<'crm.record.tab'>(({ runServerlessFunction, actions }) => (
+hubspot.extend<'crm.record.tab'>(({ actions }) => (
   <OrderMealCard
     fetchCrmObjectProperties={actions.fetchCrmObjectProperties}
-    runServerless={runServerlessFunction}
     sendAlert={actions.addAlert}
     closeOverlay={actions.closeOverlay}
   />

--- a/multi-step-flow/src/app/extensions/types.ts
+++ b/multi-step-flow/src/app/extensions/types.ts
@@ -1,7 +1,6 @@
 import type {
   AddAlertAction,
   FetchCrmObjectPropertiesAction,
-  ServerlessFuncRunner,
 } from '@hubspot/ui-extensions';
 
 export interface MenuItem {
@@ -97,7 +96,6 @@ export interface AddonsProps {
 
 export interface OrderMealProps {
   fetchCrmObjectProperties: FetchCrmObjectPropertiesAction;
-  runServerless: ServerlessFuncRunner;
   sendAlert: AddAlertAction;
   closeOverlay: (id: string) => void;
 }


### PR DESCRIPTION
_This change was previously introduced in #49 then reverted in #59, because we did not have product rollout lined up. I'm submitting this change again to finish the swing. We are hoping to have the examples updated and the API officially documented by the end of the month._

## Description

* We are introducing a simpler API, `hubspot.serverless`, for calling app functions in `@hubspot/ui-extensions@0.8.5`.
* Note that the `runServerlessFunction` way still works. 
* See [an example](https://github.com/HubSpot/ui-extensions-examples/pull/49/commits/ed4e332c87fd311bde583b48adb09bdaf01021cb) migrating from `runServerlessFunction` to `hubspot.serverless`.

_This PR is best reviewed by commits._

## Usage

With promise syntax:
```javascript
import { hubspot } from "@hubspot/ui-extensions";

hubspot.extend(() => <Extension />);

const Extension = () => {
  const handleSubmit = () => {
    hubspot
      .serverless("func-name", {
        // options, if any (e.g., propertiesToSend or parameters)
      })
      .then((response) => {
        // handle response, which is the value returned from the function on success
      })
      .catch((error) => {
        // handle error, which is an Error object if the function failed to execute
      });
  };
  return <Button onClick={handleSubmit} label="Click me" />;
}
```

With async/await syntax:
```javascript
import { hubspot } from "@hubspot/ui-extensions";

hubspot.extend(() => <Extension />);

const Extension = () => {
  const handleSubmit = async () => {
    try {
      const response = await hubspot.serverless("func-name", {
        // options, if any (e.g., propertiesToSend or parameters)
      });
      // handle response, which is the value returned from the function on success
    } catch (error) {
      // handle error, which is an Error object if the function failed to execute
    };
  };
  return <Button onClick={handleSubmit} label="Click me" />;
}
```