### PR TITLE
Updated form copy & readme example links

### DIFF
--- a/design-patterns/README.md
+++ b/design-patterns/README.md
@@ -36,11 +36,9 @@ If you haven't customized the tabs before follow step #4 from [this guide](https
 
 ## Examples by Component
 
-### Button Modal
-- [Modal Example](./src/app/extensions/components/ModalExample.tsx)
-
-### Button Panel
-- [Panel Example](./src/app/extensions/components/PanelExample.tsx)
+### Button
+- [Buttons in Modal](./src/app/extensions/components/ModalExample.tsx)
+- [Buttons in Panel](./src/app/extensions/components/PanelExample.tsx)
 
 ### Form
 - [Form Action Patterns](./src/app/extensions/FormActionPatterns.tsx)
@@ -48,9 +46,11 @@ If you haven't customized the tabs before follow step #4 from [this guide](https
 - [Multistep Form](./src/app/extensions/FormMultistep.tsx)
 
 ### Modal
+- [Buttons in Modal](./src/app/extensions/components/ModalExample.tsx)
 - [Modal Form](./src/app/extensions/FormModal.tsx)
 
 ### Panel
+- [Buttons in Panel](./src/app/extensions/components/PanelExample.tsx)
 - [Multistep Form](./src/app/extensions/FormMultistep.tsx)
 
 ### Table

--- a/design-patterns/src/app/extensions/FormModal.tsx
+++ b/design-patterns/src/app/extensions/FormModal.tsx
@@ -48,13 +48,9 @@ const FormModal = ({ actions }) => {
             >
               <ModalBody>
                 <Text>
-                  When we got all the 0's and 1's lined up, a link will show up
-                  in your{' '}
-                  <Link href="https://knowledge.hubspot.com/user-management/how-to-set-up-user-notifications-in-hubspot">
-                    Notification Center
-                  </Link>
-                  . Also, just to be sure, you're gonna get a confirmation
-                  email.
+                  This is our HubSpot pattern for a Form in Modal. Note how the
+                  Primary Button always appears to the left of the Secondary
+                  Button. Both buttons should be left aligned to the Modal.
                 </Text>
                 {
                   // Display a success message when the form is submitted.

--- a/design-patterns/src/app/extensions/FormMultistep.tsx
+++ b/design-patterns/src/app/extensions/FormMultistep.tsx
@@ -83,13 +83,10 @@ const FormMultistep = ({ actions }) => {
                       stepNames={['Info', 'Event', 'Rate', 'Followup']}
                     />
                     <Text>
-                      When we got all the 0's and 1's lined up, a link will show
-                      up in your{' '}
-                      <Link href="https://knowledge.hubspot.com/user-management/how-to-set-up-user-notifications-in-hubspot">
-                        Notification Center
-                      </Link>
-                      . Also, just to be sure, you're gonna get a confirmation
-                      email.
+                      This is our HubSpot pattern for a multistep Form in Panel.
+                      Note how the Primary Button always appears to the left of
+                      the Secondary Button. Both buttons should be left aligned
+                      to the Panel.
                     </Text>
                     {
                       // Display a success message when the form is submitted.


### PR DESCRIPTION
I updated the copy in the form design patterns to be more clear about what we are communicating.

I also did some re-arranging of the Readme links, to make the patterns easier to link to each component via JS Docs