### PR TITLE
chore: Remove references to old ui-extensions-dev-server

### DIFF
--- a/crm-data-components/src/app/extensions/package.json
+++ b/crm-data-components/src/app/extensions/package.json
@@ -14,8 +14,5 @@
   "dependencies": {
     "@hubspot/ui-extensions": "latest",
     "react": "^18.2.0"
-  },
-  "devDependencies": {
-    "@hubspot/ui-extensions-dev-server": "latest"
   }
 }

--- a/display-iframe-modal/src/app/extensions/package.json
+++ b/display-iframe-modal/src/app/extensions/package.json
@@ -4,10 +4,6 @@
   "description": "",
   "license": "MIT",
   "main": "DisplayIframe.jsx",
-  "scripts": {
-    "dev": "hs-ui-extensions-dev-server dev",
-    "build": "hs-ui-extensions-dev-server build"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/HubSpot/ui-extensions-react-examples"
@@ -15,8 +11,5 @@
   "dependencies": {
     "@hubspot/ui-extensions": "latest",
     "react": "^18.2.0"
-  },
-  "devDependencies": {
-    "@hubspot/ui-extensions-dev-server": "latest"
   }
 }


### PR DESCRIPTION
I noticed some old references to `@hubspot/ui-extensions-dev-server` in a couple projects, and wanted to remove them to prevent any confusion.

All projects should be using `hs project dev` for local developement, so these projects must have been built before that was finalized. 