### PR TITLE
[design-patterns]: add action button column in Table Example

### DIFF
--- a/design-patterns/src/app/extensions/Table.jsx
+++ b/design-patterns/src/app/extensions/Table.jsx
@@ -11,6 +11,7 @@ import {
   Heading,
   Text,
   StatusTag,
+  Button,
   hubspot,
 } from '@hubspot/ui-extensions';
 
@@ -75,11 +76,12 @@ const TableExampleCard = () => {
         <TableHead width="min">
           <TableRow>
             <TableHeader width="min">Name</TableHeader>
-            <TableHeader width="min">Publish Status</TableHeader>
             <TableHeader width="min">Review</TableHeader>
+            <TableHeader width="min">Publish Status</TableHeader>
             <TableHeader width="min">Installs</TableHeader>
             <TableHeader width="min">Last Updated</TableHeader>
             <TableHeader width="min">Created At</TableHeader>
+            <TableHeader width="min">Actions</TableHeader>
           </TableRow>
         </TableHead>
 
@@ -91,6 +93,11 @@ const TableExampleCard = () => {
             ) => (
               <TableRow key={index}>
                 <TableCell width="min">{name}</TableCell>
+                <TableCell width="min">
+                  <Button variant="secondary" size="sm">
+                    Action
+                  </Button>
+                </TableCell>
                 <TableCell width="min">
                   {['Published', 'Draft'].some((status) =>
                     publishStatus.includes(status)
@@ -110,7 +117,6 @@ const TableExampleCard = () => {
                     publishStatus
                   )}
                 </TableCell>
-
                 <TableCell width="min">{review}</TableCell>
                 <TableCell width="min">{installs}</TableCell>
                 <TableCell width="min">{lastUpdated}</TableCell>

--- a/design-patterns/src/app/extensions/Table.jsx
+++ b/design-patterns/src/app/extensions/Table.jsx
@@ -24,7 +24,6 @@ const tableData = [
     publishStatus: 'Published',
     review: '-',
     installs: '-',
-    lastUpdated: 'March 8, 2019 (Amelia Merchant)',
     createdAt: 'March 8, 2019 (Amelia Merchant)',
   },
   {
@@ -32,7 +31,6 @@ const tableData = [
     publishStatus: 'Draft',
     review: '41',
     installs: '41',
-    lastUpdated: 'March 8, 2019 (Amelia Merchant)',
     createdAt: 'March 8, 2019 (Amelia Merchant)',
   },
   {
@@ -40,7 +38,6 @@ const tableData = [
     publishStatus: 'Published | Draft',
     review: '136',
     installs: '136',
-    lastUpdated: 'March 8, 2019 (Amelia Merchant)',
     createdAt: 'March 8, 2019 (Amelia Merchant)',
   },
   {
@@ -48,7 +45,6 @@ const tableData = [
     publishStatus: 'Published',
     review: '136',
     installs: '136',
-    lastUpdated: 'March 8, 2019 (Amelia Merchant)',
     createdAt: 'March 8, 2019 (Amelia Merchant)',
   },
 ];
@@ -76,12 +72,11 @@ const TableExampleCard = () => {
         <TableHead width="min">
           <TableRow>
             <TableHeader width="min">Name</TableHeader>
-            <TableHeader width="min">Review</TableHeader>
             <TableHeader width="min">Publish Status</TableHeader>
             <TableHeader width="min">Installs</TableHeader>
             <TableHeader width="min">Last Updated</TableHeader>
-            <TableHeader width="min">Created At</TableHeader>
             <TableHeader width="min">Actions</TableHeader>
+            <TableHeader width="min">Created At</TableHeader>
           </TableRow>
         </TableHead>
 
@@ -93,11 +88,6 @@ const TableExampleCard = () => {
             ) => (
               <TableRow key={index}>
                 <TableCell width="min">{name}</TableCell>
-                <TableCell width="min">
-                  <Button variant="secondary" size="sm">
-                    Action
-                  </Button>
-                </TableCell>
                 <TableCell width="min">
                   {['Published', 'Draft'].some((status) =>
                     publishStatus.includes(status)
@@ -119,7 +109,11 @@ const TableExampleCard = () => {
                 </TableCell>
                 <TableCell width="min">{review}</TableCell>
                 <TableCell width="min">{installs}</TableCell>
-                <TableCell width="min">{lastUpdated}</TableCell>
+                <TableCell width="min">
+                  <Button variant="secondary" size="sm">
+                    Action
+                  </Button>
+                </TableCell>
                 <TableCell width="min">{createdAt}</TableCell>
               </TableRow>
             )


### PR DESCRIPTION
Following up from Design Patterns doc sync, add column of buttons in Table Example

Uploaded changes to `Design Patterns` card in `ui-extensibility` hublet in prod to check out. 

**updated screenshot** of uploaded changes to `Design Patterns` card:
![Screenshot 2025-02-06 at 3 16 23 PM](https://github.com/user-attachments/assets/b8b7c087-09bc-422f-bc3d-0a035e5ec981)

