### PR TITLE
fix: Add design patterns to template list

### DIFF
--- a/config.json
+++ b/config.json
@@ -84,6 +84,12 @@
       "label": "Charts Example with public app",
       "path": "charts-example/public",
       "insertPath": null
+    },
+    {
+      "name": "design-patterns",
+      "label": "Design Patterns",
+      "path": "design-patterns",
+      "insertPath": null
     }
   ]
 }


### PR DESCRIPTION
We want the design patterns app to be available as a template for `hs project create`, so I added it to the config. This allows this command to work:

```
hs project create --templateSource="HubSpot/ui-extensions-examples" --dest="design-patterns" --name="design-patterns" --template="design-patterns"
```