### PR TITLE
feat: Add new Data Table example

### DIFF
--- a/config.json
+++ b/config.json
@@ -90,6 +90,12 @@
       "label": "Design Patterns",
       "path": "design-patterns",
       "insertPath": null
+    },
+    {
+      "name": "data-table",
+      "label": "Data Table",
+      "path": "data-table",
+      "insertPath": null
     }
   ]
 }

--- a/data-table/LICENSE.md
+++ b/data-table/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 HubSpot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/data-table/README.md
+++ b/data-table/README.md
@@ -2,8 +2,8 @@
 
 This React Project demonstrates how to implement a paginated table that loads data retrieved from an API and displays it.
 
-![full-table]()
-![loading-state]()
+![full-table](https://github.com/user-attachments/assets/5eca2a94-6473-4299-8370-0b2066f5d08f)
+![loading-state](https://github.com/user-attachments/assets/0aa8d9f2-11b7-493c-afd6-38579ad8a1d5)
 
 ## Quick Start
 

--- a/data-table/README.md
+++ b/data-table/README.md
@@ -1,0 +1,36 @@
+# Paginated Data Table with Loading State Example ![](https://badgen.net/badge/-/TypeScript/blue?icon=typescript&label)
+
+This React Project demonstrates how to implement a paginated table that loads data retrieved from an API and displays it.
+
+![full-table]()
+![loading-state]()
+
+## Quick Start
+
+### Step 1: Update your CLI and & authenticate your account
+
+1. Update to the latest CLI version by running `npm install -g @hubspot/cli@latest`.
+1. Run `hs init` if you haven’t already done so to create a config file for your parent account.
+1. Run `hs auth` to authenticate your account. Alternatively, select your pre-authenticated account with `hs accounts use`.
+
+### Step 2: Create the project
+
+In the folder where you want this sample to be cloned, create a new project by running `hs project create --templateSource="HubSpot/ui-extensions-examples" --dest="data-table" --name="data-table" --template="data-table"`
+
+### Step 3: Install dependencies
+
+Now in the CLI, enter into this newly created folder by `cd data-table`. Run `hs project install-deps` to install the dependencies for this project.
+
+### Step 4: Upload project
+
+Run `hs project upload`. If you’d like to build directly from this project, run `hs project dev` to kickoff the dev process and see changes reflected locally as you build.
+
+### Step 5: View the cards
+
+In the main menu select `Contacts` > `Contacts` to view contact records. Click on any of the contact objects and navigate to the custom tab to access the sample card. If you don’t have any contacts in the account you’re using to view this sample, create a contact by the following steps:
+
+1. In the main menu, select `Contacts` > `Contacts`.
+2. Click `Create contact` in the top right hand corner and fill in all required fields. Click `create` once you’ve finished filling in your contact details.
+3. Your new contact should appear in the `Contacts table`. Select it and navigate to the `Custom` tab in the middle pane to access the sample card.
+
+If you haven't customized the tabs before follow step #4 from [this guide](https://developers.hubspot.com/docs/platform/ui-extensions-quickstart) to get the card added to your screen.

--- a/data-table/hsproject.json
+++ b/data-table/hsproject.json
@@ -1,0 +1,5 @@
+{
+  "name": "data-table-example",
+  "srcDir": "src",
+  "platformVersion": "2025.1"
+}

--- a/data-table/src/app/extensions/DataTable.tsx
+++ b/data-table/src/app/extensions/DataTable.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+import {
+  Text,
+  hubspot,
+  Table,
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableCell,
+  LoadingSpinner,
+  Flex,
+  Image,
+} from "@hubspot/ui-extensions";
+
+const PAGE_SIZE = 5;
+
+interface Artwork {
+  id: number;
+  title: string | null;
+  artist_display: string | null;
+  date_display: string | null;
+  image_id: string | null;
+}
+
+hubspot.extend(() => <DataTable />);
+
+const DataTable = () => {
+  const [artworks, setArtworks] = useState<Artwork[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  useEffect(() => {
+    let ignore = false;
+    const fetchData = async () => {
+      setLoading(true);
+      const url = `https://api.artic.edu/api/v1/artworks?page=${page}&limit=${PAGE_SIZE}&fields=id,title,artist_display,date_display,image_id`;
+      const response = await hubspot.fetch(url, { method: "GET" });
+      if (!ignore) {
+        const data = await response.json();
+        setArtworks(data.data);
+        setTotalPages(data.pagination ? data.pagination.total_pages : 1);
+        setLoading(false);
+      }
+    };
+    fetchData();
+    return () => { ignore = true; };
+  }, [page]);
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  return (
+    <>
+      <Table
+        paginated={true}
+        pageCount={totalPages}
+        page={page}
+        onPageChange={handlePageChange}
+      >
+        <TableHead>
+          <TableRow>
+            <TableHeader>Image</TableHeader>
+            <TableHeader>Title</TableHeader>
+            <TableHeader>Artist</TableHeader>
+            <TableHeader>Date</TableHeader>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {loading ? (
+            <TableRow>
+              <TableCell colSpan={4}>
+                <Flex direction="column" align="center" gap="md">
+                  <LoadingSpinner showLabel layout="centered" size="md" label="Loading..." />
+                </Flex>
+              </TableCell>
+            </TableRow>
+          ) : (
+            artworks.map((art) => (
+              <TableRow key={art.id}>
+                <TableCell>
+                  {art.image_id ? (
+                    <Image
+                      src={`https://www.artic.edu/iiif/2/${art.image_id}/full/400,/0/default.jpg`}
+                      alt={art.title || "Artwork image"}
+                      width={200}
+                    />
+                  ) : (
+                    <Text>No image</Text>
+                  )}
+                </TableCell>
+                <TableCell><Text>{art.title || "Untitled"}</Text></TableCell>
+                <TableCell><Text>{art.artist_display || "Unknown"}</Text></TableCell>
+                <TableCell><Text>{art.date_display || "N/A"}</Text></TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </>
+  );
+};

--- a/data-table/src/app/extensions/data-table.json
+++ b/data-table/src/app/extensions/data-table.json
@@ -1,0 +1,16 @@
+{
+  "type": "crm-card",
+  "data": {
+    "title": "Data Table Example",
+    "uid": "data-table-example",
+    "location": "crm.record.tab",
+    "module": {
+      "file": "DataTable.tsx"
+    },
+    "objectTypes":[
+      {
+        "name": "contacts"
+      }
+    ]
+  }
+}

--- a/data-table/src/app/extensions/package.json
+++ b/data-table/src/app/extensions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "data-table-example",
+  "version": "0.1.0",
+  "dependencies": {
+    "@hubspot/ui-extensions": "latest",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/data-table/src/app/public-app.json
+++ b/data-table/src/app/public-app.json
@@ -1,0 +1,27 @@
+{
+  "name": "Data Table Example",
+  "uid": "data-table-example",
+  "description": "An example to demonstrate data table extensions",
+  "allowedUrls": ["https://api.artic.edu"],
+  "auth": {
+    "redirectUrls": ["http://localhost:3000/oauth-callback"],
+    "requiredScopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
+    "optionalScopes": [],
+    "conditionallyRequiredScopes": []
+  },
+  "support": {
+    "supportEmail": "support@example.com",
+    "documentationUrl": "https://example.com/docs",
+    "supportUrl": "https://example.com/support",
+    "supportPhone": "+18005555555"
+  },
+  "extensions": {
+    "crm": {
+      "cards": [
+        {
+          "file": "./extensions/data-table.json"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Example Description

This is a new example to demonstrate how to build a table which displays data from an external API. It shows how to use pagination, as well as demonstrates a good loading state.

<img width="2113" alt="data-table-loading" src="https://github.com/user-attachments/assets/0aa8d9f2-11b7-493c-afd6-38579ad8a1d5" />
<img width="2066" alt="data-table" src="https://github.com/user-attachments/assets/5eca2a94-6473-4299-8370-0b2066f5d08f" />
