### PR TITLE
Add 2025.2 Example Project

### DIFF
--- a/example-2025-2-project/AGENTS.md
+++ b/example-2025-2-project/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+IMPORTANT: IF THE 'HubSpotDev' MCP SERVER IS INSTALLED USE THE TOOLS BEFORE TRYING TO MANUALLY USE CLI COMMANDS OR BEFORE TRYING TO DO ANYTHING WITH HUBSPOT ASSETS
+
+## HubSpot Project Information
+- The project configuration is in the `hsproject.json` file
+- A directory is considered a part of the project it or a directory above it contains a `hsproject.json` file
+- The project src directory is defined in the `srcDir` field in the `hsproject.json`
+- The project's platform version is defined in `platformVersion` in the `hs project.json`
+- The `platformVersion` determines what features the project has access to as well as the shape of the configuration files
+
+## npm packages
+### `@hubspot/ui-extensions`
+- In the `@hubspot/ui-extensions` npm package, only the component properties defined by the component are valid.  `style` properties are not valid
+
+## Component Information
+### General
+- Component configuration files must end with `-hsmeta.json`
+- The `uid` field in the `-hsmeta.json` files must be unique with the project
+- The `type` field in the `-hsmeta.json` files defines the type of the component
+- Components can not be in nested subdirectories, only the specified directories in their corresponding component rules.
+- Example components can be found in https://github.com/HubSpot/hubspot-project-components.  The directories are split up by platform version and follow this format `${platformVersion}/components`
+- All component subdirectories must be in the project source directory
+
+### app component
+- There can only be one `app` component
+- `app` component must be in the `app` directory
+- If the `config.distribution` field is set to `marketplace`, the only valid `config.auth.type` value is `oauth`
+
+### card
+- `card` components must be in the `app/cards` directory
+- The global `window` object is not available in the `card` component
+- Cannot use `window.fetch`, and instead must use the `hubspot.fetch` function provided by the `@hubspot/ui-extensions` npm package.  Any urls called with the `hubspot.fetch` function must be added to the `config.permittedUrls.fetch` array in the `app` component's hsmeta.json file
+- Only components exported from the `@hubspot/ui-extensions` npm package can be used in `card` components
+
+### app-event
+- `app-event` components must be in the `app/app-events` directory
+-
+### app-object
+- `app-object` components must be in the `app/app-object` directory
+
+### app-function
+- `app-function` components must be in the `app/functions` directory
+- `app-function` components are not available when `config.distribution` is set to `marketplace` in the `app` component `-hsmeta.son` file
+
+# settings
+- There can only be one `settings` component
+- `settings` components must be in the `app/settings` directory
+- The global `window` object is not available in the `settings` component
+- Cannot use `window.fetch`, and instead must use the `hubspot.fetch` function provided by the `@hubspot/ui-extensions` npm package.  Any urls called with the `hubspot.fetch` function must be added to the `config.permittedUrls.fetch` array in the `app` component's hsmeta.json file
+- Only components exported from the `@hubspot/ui-extensions` npm package can be used in `settings` components
+- React Components from `@hubspot/ui-extensions/crm` cannot be used in `settings` components
+
+# scim
+- There can only be one `scim` component
+- `scim` components must be in the `app/scim` directory
+
+# webhooks
+- There can only be one `webhooks` component.
+- `webhooks` components must be in the `app/webhooks` directory
+- `webhooks` components can only be in projects where `config.distribution` is private and `config.auth.type` is `static`
+
+### workflow-actions
+- `workflow-action` components must be in the `app/workflow-actions` directory
+
+## HubSpot CLI commands
+- All the commands and subcommands have a `--help` argument that provides details on the command and it's arguments
+- The help output is standard yargs output
+- The commands for working with projects in HubSpot are subcommands of `hs project`
+- Debugging flag that can be added to `hs` commands and subcommands: `--debug`
+- Debugging problems with CLI installation: `hs doctor`
+- `hs project open` will open the current project page in the browser
+- `hs init` is required to set up the hubspot configuration file
+- `hs auth` will authenticate a new account.  This will require a user to open a browser and paste a token in a CLI prompt.
+- All the commands for managing HubSpot accounts in the CLI are subcommands of `hs account`
+
+## General
+- Follow existing patterns in the codebase
+- Use proper component structure based on component `type` in the `-hsmeta.json` file
+- Ensure configuration files follow HubSpot naming conventions
+- Always validate that components are placed in correct directories

--- a/example-2025-2-project/CLAUDE.md
+++ b/example-2025-2-project/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working on HubSpot components
+
+IMPORTANT: IF THE 'HubSpotDev' MCP SERVER IS INSTALLED USE THE TOOLS BEFORE TRYING TO MANUALLY USE CLI COMMANDS OR BEFORE TRYING TO DO ANYTHING WITH HUBSPOT ASSETS
+
+## HubSpot Project Information
+- The project configuration is in the `hsproject.json` file
+- A directory is considered a part of the project it or a directory above it contains a `hsproject.json` file
+- The project src directory is defined in the `srcDir` field in the `hsproject.json`
+- The project's platform version is defined in `platformVersion` in the `hs project.json`
+- The `platformVersion` determines what features the project has access to as well as the shape of the configuration files
+
+## npm packages
+### `@hubspot/ui-extensions`
+- In the `@hubspot/ui-extensions` npm package, only the component properties defined by the component are valid.  `style` properties are not valid
+
+## Component Information
+### General
+- Component configuration files must end with `-hsmeta.json`
+- The `uid` field in the `-hsmeta.json` files must be unique with the project
+- The `type` field in the `-hsmeta.json` files defines the type of the component
+- Components can not be in nested subdirectories, only the specified directories in their corresponding component rules.
+- Example components can be found in https://github.com/HubSpot/hubspot-project-components.  The directories are split up by platform version and follow this format `${platformVersion}/components`
+- All component subdirectories must be in the project source directory
+
+### app component
+- There can only be one `app` component
+- `app` component must be in the `app` directory
+- If the `config.distribution` field is set to `marketplace`, the only valid `config.auth.type` value is `oauth` 
+
+### card
+- `card` components must be in the `app/cards` directory
+- The global `window` object is not available in the `card` component
+- Cannot use `window.fetch`, and instead must use the `hubspot.fetch` function provided by the `@hubspot/ui-extensions` npm package.  Any urls called with the `hubspot.fetch` function must be added to the `config.permittedUrls.fetch` array in the `app` component's hsmeta.json file
+- Only components exported from the `@hubspot/ui-extensions` npm package can be used in `card` components 
+
+### app-event
+- `app-event` components must be in the `app/app-events` directory
+- 
+### app-object
+- `app-object` components must be in the `app/app-object` directory
+
+### app-function
+- `app-function` components must be in the `app/functions` directory
+- `app-function` components are not available when `config.distribution` is set to `marketplace` in the `app` component `-hsmeta.son` file 
+
+# settings
+- There can only be one `settings` component
+- `settings` components must be in the `app/settings` directory
+- The global `window` object is not available in the `settings` component
+- Cannot use `window.fetch`, and instead must use the `hubspot.fetch` function provided by the `@hubspot/ui-extensions` npm package.  Any urls called with the `hubspot.fetch` function must be added to the `config.permittedUrls.fetch` array in the `app` component's hsmeta.json file
+- Only components exported from the `@hubspot/ui-extensions` npm package can be used in `settings` components
+- React Components from `@hubspot/ui-extensions/crm` cannot be used in `settings` components
+
+# scim
+- There can only be one `scim` component
+- `scim` components must be in the `app/scim` directory
+
+# webhooks
+- There can only be one `webhooks` component.
+- `webhooks` components must be in the `app/webhooks` directory
+- `webhooks` components can only be in projects where `config.distribution` is private and `config.auth.type` is `static`
+
+### workflow-actions
+- `workflow-action` components must be in the `app/workflow-actions` directory
+
+## HubSpot CLI commands
+- All the commands and subcommands have a `--help` argument that provides details on the command and it's arguments
+- The help output is standard yargs output
+- The commands for working with projects in HubSpot are subcommands of `hs project`
+- Debugging flag that can be added to `hs` commands and subcommands: `--debug`
+- Debugging problems with CLI installation: `hs doctor`
+- `hs project open` will open the current project page in the browser
+- `hs init` is required to set up the hubspot configuration file
+- `hs auth` will authenticate a new account.  This will require a user to open a browser and paste a token in a CLI prompt.
+- All the commands for managing HubSpot accounts in the CLI are subcommands of `hs account`
+
+## General
+- Follow existing patterns in the codebase
+- Use proper component structure based on component `type` in the `-hsmeta.json` file
+- Ensure configuration files follow HubSpot naming conventions 
+- Always validate that components are placed in correct directories

--- a/example-2025-2-project/hsproject.json
+++ b/example-2025-2-project/hsproject.json
@@ -1,0 +1,5 @@
+{
+  "name": "Example20252Project",
+  "srcDir": "src",
+  "platformVersion": "2025.2"
+}

--- a/example-2025-2-project/src/app/app-hsmeta.json
+++ b/example-2025-2-project/src/app/app-hsmeta.json
@@ -1,0 +1,32 @@
+{
+  "uid": "app-Example20252Project",
+  "type": "app",
+  "config": {
+    "description": "An example to demonstrate how to build a static private app with developer projects.",
+    "name": "Example20252Project-Application",
+    "distribution": "private",
+    "auth": {
+      "type": "static",
+      "requiredScopes": [
+        "oauth",
+        "crm.objects.contacts.read",
+        "crm.objects.contacts.write"
+      ],
+      "optionalScopes": [],
+      "conditionallyRequiredScopes": []
+    },
+    "permittedUrls": {
+      "fetch": [
+        "https://api.hubapi.com"
+      ],
+      "iframe": [],
+      "img": []
+    },
+    "support": {
+      "supportEmail": "support@example.com",
+      "documentationUrl": "https://example.com/docs",
+      "supportUrl": "https://example.com/support",
+      "supportPhone": "+18005555555"
+    }
+  }
+}

--- a/example-2025-2-project/src/app/cards/NewCard.tsx
+++ b/example-2025-2-project/src/app/cards/NewCard.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { EmptyState, Link, Text } from "@hubspot/ui-extensions";
+import { hubspot } from "@hubspot/ui-extensions";
+
+hubspot.extend(({ context }) => <Extension context={context} />);
+
+const Extension = ({ context }) => {
+
+  const appCardDocsLink = 'https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensibility/app-cards/overview';
+
+  console.log({context});
+
+  return (
+    <>
+      <EmptyState
+        title="Build your app card here!"
+        layout="vertical"
+        imageName='building'
+      >
+        <Text>
+          Add a layer of UI customization to your app by including app cards that can display data, allow users to perform actions, and more.
+          Check out the <Link href={appCardDocsLink}>app card documentation</Link> for more info.
+        </Text>
+      </EmptyState>
+    </>
+  );
+};

--- a/example-2025-2-project/src/app/cards/card-hsmeta.json
+++ b/example-2025-2-project/src/app/cards/card-hsmeta.json
@@ -1,0 +1,12 @@
+{
+  "uid": "card-example-2025-2-project",
+  "type": "card",
+  "config": {
+    "name": "New Card",
+    "location": "crm.record.tab",
+    "entrypoint": "/app/cards/NewCard.tsx",
+    "objectTypes": [
+      "contacts"
+    ]
+  }
+}

--- a/example-2025-2-project/src/app/cards/package.json
+++ b/example-2025-2-project/src/app/cards/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hubspot-example-extension",
+  "version": "0.1.0",
+  "license": "MIT",
+  "dependencies": {
+    "@hubspot/ui-extensions": "latest",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.37.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/example-2025-2-project/src/app/pages/Home.tsx
+++ b/example-2025-2-project/src/app/pages/Home.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { EmptyState, Link, Text, hubspot } from "@hubspot/ui-extensions";
+import { HeaderActions, PrimaryHeaderActionButton, SecondaryHeaderActionButton } from "@hubspot/ui-extensions/pages/home";
+
+hubspot.extend<"home">(({ context }) => {
+  return <AppHomePage context={context} />;
+});
+
+const AppHomePage = ({ context }) => {
+
+  console.log({context});
+
+  const appHomesDocsLink = 'https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensibility/create-an-app-home-page#create-an-app-home-page';
+
+  return (
+    <>
+      <HeaderActions>
+        <PrimaryHeaderActionButton onClick={() => console.log('Primary Header Action 1')}>
+          Primary 1
+        </PrimaryHeaderActionButton>
+        <SecondaryHeaderActionButton onClick={() => console.log('Secondary Header Action 1')}>
+          Secondary 1
+        </SecondaryHeaderActionButton>
+        <SecondaryHeaderActionButton onClick={() => console.log('Secondary Header Action 2')}>
+          Secondary 2
+        </SecondaryHeaderActionButton>
+      </HeaderActions>
+      <EmptyState
+        title="Build your application home page here!"
+        layout="horizontal"
+        imageName='building'
+      >
+        <Text>
+          The app home page is a custom landing experience for your app in HubSpot.
+          Check out the <Link href={appHomesDocsLink}>app home page documentation</Link> for more info.
+        </Text>
+      </EmptyState>
+    </>
+  );
+};

--- a/example-2025-2-project/src/app/pages/home-hsmeta.json
+++ b/example-2025-2-project/src/app/pages/home-hsmeta.json
@@ -1,0 +1,8 @@
+{
+  "uid": "page-example-2025-2-project",
+  "type": "page",
+  "config": {
+    "entrypoint": "/app/pages/Home.tsx",
+    "location": "home"
+  }
+}

--- a/example-2025-2-project/src/app/pages/package.json
+++ b/example-2025-2-project/src/app/pages/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hubspot-example-extension",
+  "version": "0.1.0",
+  "license": "MIT",
+  "dependencies": {
+    "@hubspot/ui-extensions": "latest",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.37.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/example-2025-2-project/src/app/settings/SettingsPage.tsx
+++ b/example-2025-2-project/src/app/settings/SettingsPage.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { EmptyState, Link, Text } from "@hubspot/ui-extensions";
+import { hubspot } from "@hubspot/ui-extensions";
+
+hubspot.extend<"settings">(({ context }) => <SettingsPage context={context}/>);
+
+const SettingsPage = ({ context }) => {
+
+  console.log({context});
+
+  const appSettingsDocsLink = 'https://developers.hubspot.com/docs/apps/developer-platform/add-features/ui-extensibility/create-a-settings-component';
+
+  return (
+    <>
+      <EmptyState
+        title="Build your Settings page here!"
+        layout="horizontal"
+        imageName='building'
+      >
+        <Text>
+          Add configuration and customization settings for your app, linked to directly from your app cards.
+          Check out the <Link href={appSettingsDocsLink}>app settings documentation</Link> for more info.
+        </Text>
+      </EmptyState>
+    </>
+  );
+};

--- a/example-2025-2-project/src/app/settings/package.json
+++ b/example-2025-2-project/src/app/settings/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hubspot-example-extension",
+  "version": "0.1.0",
+  "license": "MIT",
+  "dependencies": {
+    "@hubspot/ui-extensions": "latest",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.37.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/example-2025-2-project/src/app/settings/settings-page-hsmeta.json
+++ b/example-2025-2-project/src/app/settings/settings-page-hsmeta.json
@@ -1,0 +1,7 @@
+{
+  "uid": "settings-example-2025-2-project",
+  "type": "settings",
+  "config": {
+    "entrypoint": "/app/settings/SettingsPage.tsx"
+  }
+}

--- a/example-2025-2-project/src/app/webhooks/webhooks-hsmeta.json
+++ b/example-2025-2-project/src/app/webhooks/webhooks-hsmeta.json
@@ -1,0 +1,42 @@
+{
+  "uid": "webhooks-Example20252Project",
+  "type": "webhooks",
+  "config": {
+    "settings": {
+      "targetUrl": "https://example.com/webhook",
+      "maxConcurrentRequests": 10
+    },
+    "subscriptions": {
+      "crmObjects": [
+        {
+          "subscriptionType": "object.creation",
+          "objectType": "contact",
+          "active": true
+        },
+        {
+          "subscriptionType": "object.propertyChange",
+          "objectType": "contact",
+          "propertyName": "firstname",
+          "active": true
+        }
+      ],
+      "legacyCrmObjects": [
+        {
+          "subscriptionType": "contact.propertyChange",
+          "propertyName": "lastname",
+          "active": true
+        },
+        {
+          "subscriptionType": "contact.deletion",
+          "active": true
+        }
+      ],
+      "hubEvents": [
+        {
+          "subscriptionType": "contact.privacyDeletion",
+          "active": true
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds the boilerplate 2025.2 project to give a basic example of what components look like in 2025.2. I believe eventually we should switch all the examples to the most recent project version, but, for now, lets give a place for people to see the project structure from where they may be used to viewing it!