### PR TITLE
fix(StatusValue): Use optionType fallback form dynamic properties not in definition.json

### DIFF
--- a/2025.2/legacy-card-converter/src/app/cards/components/Properties/StatusValue.tsx
+++ b/2025.2/legacy-card-converter/src/app/cards/components/Properties/StatusValue.tsx
@@ -10,14 +10,23 @@ export interface StatusValueProps {
   testId?: string;
 }
 
-export function StatusValue({ value, name, testId }: StatusValueProps) {
+export function StatusValue({ value, name, optionType, testId }: StatusValueProps) {
   const config = useCardConfig();
   const statusPropFromConfig = config.getStatusProperty({
     parentPropertyName: name,
     statusPropertyName: value,
   });
 
-  if (!statusPropFromConfig) {
+  // For dynamic properties in the response `properties` array, a config lookup
+  // isn't possible (no matching name in DEFINITION.json). Use the optionType
+  // sent directly in the response as a fallback.
+  const variant = statusPropFromConfig
+    ? getStatusVariant(statusPropFromConfig.type)
+    : optionType
+      ? getStatusVariant(optionType)
+      : null;
+
+  if (!variant) {
     return (
       <Text variant='microcopy' inline={true} testId={testId}>
         Invalid property
@@ -25,13 +34,11 @@ export function StatusValue({ value, name, testId }: StatusValueProps) {
     );
   }
 
+  const label = statusPropFromConfig?.label ?? String(value);
+
   return (
-    <Tag
-      variant={getStatusVariant(statusPropFromConfig.type)}
-      inline={true}
-      testId={testId}
-    >
-      {statusPropFromConfig.label}
+    <Tag variant={variant} inline={true} testId={testId}>
+      {label}
     </Tag>
   );
 }

--- a/2025.2/legacy-card-converter/src/app/cards/components/__test__/PropertyValue.test.tsx
+++ b/2025.2/legacy-card-converter/src/app/cards/components/__test__/PropertyValue.test.tsx
@@ -394,6 +394,26 @@ describe('PropertyValue', () => {
       expect(displayValue.text).toContain('Invalid property');
     });
 
+    it('renders status tag using optionType fallback for dynamic properties not in config', () => {
+      const { render, findByTestId } = createRenderer('crm.record.tab');
+      const property: CardProperty = {
+        label: 'Status',
+        dataType: 'STATUS',
+        value: 'Active',
+        optionType: 'SUCCESS',
+      };
+
+      // No name provided — simulates a property from the `properties` array that
+      // isn't defined in DEFINITION.json. The config lookup will fail; the
+      // component should fall back to optionType for the badge color and use
+      // value as the label.
+      render(<PropertyValue property={property} />);
+
+      const tag = findByTestId(Tag, getTestId(property, 'value'));
+      expect(tag.props.variant).toBe('success');
+      expect(tag.text).toBe('Active');
+    });
+
     it('renders "Invalid property" when property name is not provided and optionType is missing', () => {
       const { render, findByTestId } = createRenderer('crm.record.tab');
       const property: CardProperty = {

--- a/legacy-card-converter/src/app/cards/components/Properties/StatusValue.tsx
+++ b/legacy-card-converter/src/app/cards/components/Properties/StatusValue.tsx
@@ -10,14 +10,23 @@ export interface StatusValueProps {
   testId?: string;
 }
 
-export function StatusValue({ value, name, testId }: StatusValueProps) {
+export function StatusValue({ value, name, optionType, testId }: StatusValueProps) {
   const config = useCardConfig();
   const statusPropFromConfig = config.getStatusProperty({
     parentPropertyName: name,
     statusPropertyName: value,
   });
 
-  if (!statusPropFromConfig) {
+  // For dynamic properties in the response `properties` array, a config lookup
+  // isn't possible (no matching name in DEFINITION.json). Use the optionType
+  // sent directly in the response as a fallback.
+  const variant = statusPropFromConfig
+    ? getStatusVariant(statusPropFromConfig.type)
+    : optionType
+      ? getStatusVariant(optionType)
+      : null;
+
+  if (!variant) {
     return (
       <Text variant='microcopy' inline={true} testId={testId}>
         Invalid property
@@ -25,13 +34,11 @@ export function StatusValue({ value, name, testId }: StatusValueProps) {
     );
   }
 
+  const label = statusPropFromConfig?.label ?? String(value);
+
   return (
-    <Tag
-      variant={getStatusVariant(statusPropFromConfig.type)}
-      inline={true}
-      testId={testId}
-    >
-      {statusPropFromConfig.label}
+    <Tag variant={variant} inline={true} testId={testId}>
+      {label}
     </Tag>
   );
 }

--- a/legacy-card-converter/src/app/cards/components/__test__/PropertyValue.test.tsx
+++ b/legacy-card-converter/src/app/cards/components/__test__/PropertyValue.test.tsx
@@ -394,6 +394,26 @@ describe('PropertyValue', () => {
       expect(displayValue.text).toContain('Invalid property');
     });
 
+    it('renders status tag using optionType fallback for dynamic properties not in config', () => {
+      const { render, findByTestId } = createRenderer('crm.record.tab');
+      const property: CardProperty = {
+        label: 'Status',
+        dataType: 'STATUS',
+        value: 'Active',
+        optionType: 'SUCCESS',
+      };
+
+      // No name provided — simulates a property from the `properties` array that
+      // isn't defined in DEFINITION.json. The config lookup will fail; the
+      // component should fall back to optionType for the badge color and use
+      // value as the label.
+      render(<PropertyValue property={property} />);
+
+      const tag = findByTestId(Tag, getTestId(property, 'value'));
+      expect(tag.props.variant).toBe('success');
+      expect(tag.text).toBe('Active');
+    });
+
     it('renders "Invalid property" when property name is not provided and optionType is missing', () => {
       const { render, findByTestId } = createRenderer('crm.record.tab');
       const property: CardProperty = {


### PR DESCRIPTION
This PR updates the legacy card converter to use the provided `optionType` value for statuses whenever a property is not defined directly in definition.json, avoiding unnecessary "invalid property" messaging.